### PR TITLE
🐛 Removed additionalProperties from resources so allOf doesn't break

### DIFF
--- a/specification/paths/Carriers-carrier_id-PickupDropoffLocations-country_code-postal_code.json
+++ b/specification/paths/Carriers-carrier_id-PickupDropoffLocations-country_code-postal_code.json
@@ -26,7 +26,7 @@
       "200": {
         "description": "Retrieved the locations.",
         "content": {
-          "application/vnd.json+api": {
+          "application/vnd.api+json": {
             "schema": {
               "type": "object",
               "required": [

--- a/specification/paths/PasswordResets-password_reset_id.json
+++ b/specification/paths/PasswordResets-password_reset_id.json
@@ -20,7 +20,6 @@
             "required": [
               "data"
             ],
-            "additionalProperties": false,
             "properties": {
               "data": {
                 "allOf": [
@@ -32,7 +31,6 @@
                       "id",
                       "attributes"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "readOnly": false

--- a/specification/paths/PasswordResets.json
+++ b/specification/paths/PasswordResets.json
@@ -15,7 +15,6 @@
             "required": [
               "data"
             ],
-            "additionalProperties": false,
             "properties": {
               "data": {
                 "allOf": [
@@ -26,7 +25,6 @@
                     "required": [
                       "attributes"
                     ],
-                    "additionalProperties": false,
                     "properties": {
                       "attributes": {
                         "type": "object",

--- a/specification/paths/SystemMessages-system_message_id.json
+++ b/specification/paths/SystemMessages-system_message_id.json
@@ -23,7 +23,23 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "$ref": "#/components/schemas/SystemMessage"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SystemMessage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "required": [
+                            "level",
+                            "content"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -76,7 +92,23 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "$ref": "#/components/schemas/SystemMessage"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SystemMessage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "required": [
+                            "level",
+                            "content"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/specification/paths/SystemMessages.json
+++ b/specification/paths/SystemMessages.json
@@ -22,7 +22,23 @@
                 "data": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/SystemMessage"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/SystemMessage"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "attributes": {
+                            "type": "object",
+                            "required": [
+                              "level",
+                              "content"
+                            ]
+                          }
+                        }
+                      }
+                    ]
                   }
                 },
                 "meta": {
@@ -85,7 +101,23 @@
             "additionalProperties": false,
             "properties": {
               "data": {
-                "$ref": "#/components/schemas/SystemMessage"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SystemMessage"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "attributes": {
+                        "type": "object",
+                        "required": [
+                          "level",
+                          "content"
+                        ]
+                      }
+                    }
+                  }
+                ]
               }
             }
           }

--- a/specification/paths/SystemMessages.json
+++ b/specification/paths/SystemMessages.json
@@ -137,7 +137,23 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "$ref": "#/components/schemas/SystemMessage"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SystemMessage"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "required": [
+                            "level",
+                            "content"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/specification/paths/Users-user_id.json
+++ b/specification/paths/Users-user_id.json
@@ -23,7 +23,25 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "$ref": "#/components/schemas/User"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    {
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "required": [
+                            "first_name",
+                            "last_name",
+                            "company",
+                            "email",
+                            "phone_number"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -76,7 +94,25 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "$ref": "#/components/schemas/User"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    {
+                      "properties": {
+                        "attributes": {
+                          "type": "object",
+                          "required": [
+                            "first_name",
+                            "last_name",
+                            "company",
+                            "email",
+                            "phone_number"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/specification/paths/Users.json
+++ b/specification/paths/Users.json
@@ -22,7 +22,25 @@
                 "data": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/User"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/User"
+                      },
+                      {
+                        "properties": {
+                          "attributes": {
+                            "type": "object",
+                            "required": [
+                              "first_name",
+                              "last_name",
+                              "company",
+                              "email",
+                              "phone_number"
+                            ]
+                          }
+                        }
+                      }
+                    ]
                   }
                 },
                 "meta": {

--- a/specification/schemas/Carrier.json
+++ b/specification/schemas/Carrier.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/File.json
+++ b/specification/schemas/File.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/Invitation.json
+++ b/specification/schemas/Invitation.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/MinimalCarrier.json
+++ b/specification/schemas/MinimalCarrier.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalCarrierContract.json
+++ b/specification/schemas/MinimalCarrierContract.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalFile.json
+++ b/specification/schemas/MinimalFile.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalInvitation.json
+++ b/specification/schemas/MinimalInvitation.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalPasswordReset.json
+++ b/specification/schemas/MinimalPasswordReset.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalPickupDropoffLocation.json
+++ b/specification/schemas/MinimalPickupDropoffLocation.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalRegion.json
+++ b/specification/schemas/MinimalRegion.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalService.json
+++ b/specification/schemas/MinimalService.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalServiceContract.json
+++ b/specification/schemas/MinimalServiceContract.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalServiceGroup.json
+++ b/specification/schemas/MinimalServiceGroup.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalServiceInsurance.json
+++ b/specification/schemas/MinimalServiceInsurance.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalServiceOption.json
+++ b/specification/schemas/MinimalServiceOption.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalServiceOptionPrice.json
+++ b/specification/schemas/MinimalServiceOptionPrice.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalShipment.json
+++ b/specification/schemas/MinimalShipment.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalShipmentStatus.json
+++ b/specification/schemas/MinimalShipmentStatus.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalShop.json
+++ b/specification/schemas/MinimalShop.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalStatus.json
+++ b/specification/schemas/MinimalStatus.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalSystemMessage.json
+++ b/specification/schemas/MinimalSystemMessage.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalUser.json
+++ b/specification/schemas/MinimalUser.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalWebhook.json
+++ b/specification/schemas/MinimalWebhook.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/MinimalWebhookSubscription.json
+++ b/specification/schemas/MinimalWebhookSubscription.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",

--- a/specification/schemas/PickupDropoffLocation.json
+++ b/specification/schemas/PickupDropoffLocation.json
@@ -9,7 +9,6 @@
         "attributes",
         "relationships"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/Region.json
+++ b/specification/schemas/Region.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/Service.json
+++ b/specification/schemas/Service.json
@@ -9,7 +9,6 @@
         "attributes",
         "relationships"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/ServiceContractRelationship.json
+++ b/specification/schemas/ServiceContractRelationship.json
@@ -1,8 +1,7 @@
 {
   "type": "object",
   "required": [
-    "data",
-    "links"
+    "data"
   ],
   "additionalProperties": false,
   "properties": {

--- a/specification/schemas/ServiceContractsRelationship.json
+++ b/specification/schemas/ServiceContractsRelationship.json
@@ -27,7 +27,7 @@
       "properties": {
         "related": {
           "type": "string",
-          "example": "$API_HOST/services/d35a7388-5300-49f9-9a84-01ca549a7775/contracts/af5e65b6-a709-4f61-a565-7c12a752482f"
+          "example": "$API_HOST/services/d35a7388-5300-49f9-9a84-01ca549a7775/contracts"
         }
       }
     }

--- a/specification/schemas/ServiceGroup.json
+++ b/specification/schemas/ServiceGroup.json
@@ -10,7 +10,6 @@
         "relationships",
         "links"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/ServiceInsurance.json
+++ b/specification/schemas/ServiceInsurance.json
@@ -10,7 +10,6 @@
         "relationships",
         "links"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/ServiceOption.json
+++ b/specification/schemas/ServiceOption.json
@@ -9,7 +9,6 @@
         "attributes",
         "links"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/ServiceOptionPrice.json
+++ b/specification/schemas/ServiceOptionPrice.json
@@ -10,7 +10,6 @@
         "relationships",
         "links"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/ServiceOptionRelationship.json
+++ b/specification/schemas/ServiceOptionRelationship.json
@@ -1,8 +1,7 @@
 {
   "type": "object",
   "required": [
-    "data",
-    "links"
+    "data"
   ],
   "additionalProperties": false,
   "properties": {

--- a/specification/schemas/ShipmentStatus.json
+++ b/specification/schemas/ShipmentStatus.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/Shop.json
+++ b/specification/schemas/Shop.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/Status.json
+++ b/specification/schemas/Status.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/SystemMessage.json
+++ b/specification/schemas/SystemMessage.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/SystemMessage.json
+++ b/specification/schemas/SystemMessage.json
@@ -11,10 +11,6 @@
       "properties": {
         "attributes": {
           "type": "object",
-          "required": [
-            "level",
-            "content"
-          ],
           "additionalProperties": false,
           "properties": {
             "level": {

--- a/specification/schemas/User.json
+++ b/specification/schemas/User.json
@@ -11,13 +11,6 @@
       "properties": {
         "attributes": {
           "type": "object",
-          "required": [
-            "first_name",
-            "last_name",
-            "company",
-            "email",
-            "phone_number"
-          ],
           "additionalProperties": false,
           "properties": {
             "first_name": {

--- a/specification/schemas/User.json
+++ b/specification/schemas/User.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/Webhook.json
+++ b/specification/schemas/Webhook.json
@@ -8,7 +8,6 @@
       "required": [
         "attributes"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",

--- a/specification/schemas/WebhookSubscription.json
+++ b/specification/schemas/WebhookSubscription.json
@@ -9,7 +9,6 @@
         "attributes",
         "relationships"
       ],
-      "additionalProperties": false,
       "properties": {
         "attributes": {
           "type": "object",


### PR DESCRIPTION
We can't use `allOf` in the schema to combine 2 objects if one of them has `additionalProperties:false`