### PR TITLE
Add with_contract filter to services endpoint

### DIFF
--- a/specification/paths/Services.json
+++ b/specification/paths/Services.json
@@ -37,6 +37,14 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "filter[with_contract]",
+        "in": "query",
+        "description": "Boolean value. <ul><li>true: Only services with active contract associations</li><li>false: Only services without active contract associates</li></ul>",
+        "schema": {
+          "type": "boolean"
+        }
       }
     ],
     "responses": {

--- a/specification/paths/Services.json
+++ b/specification/paths/Services.json
@@ -41,7 +41,7 @@
       {
         "name": "filter[with_contract]",
         "in": "query",
-        "description": "Boolean value. <ul><li>true: Only services with active contract associations</li><li>false: Only services without active contract associates</li></ul>",
+        "description": "Boolean value. <ul><li>true: Only services with active contract associations</li><li>false: Only services without active contract associations</li></ul>",
         "schema": {
           "type": "boolean"
         }


### PR DESCRIPTION
*Changes*
- Add `with_contract` filter option to `GET /services` endpoint to only return services with active contracts or vice versa

*Related issues*
- https://myparcelcombv.atlassian.net/browse/MP-789