### PR TITLE
Add carrier filter to GET /shipments endpoint

### DIFF
--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -29,6 +29,14 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "filter[carrier]",
+        "in": "query",
+        "description": "Comma separated string of carrier ids to filter by.",
+        "schema": {
+          "type": "string"
+        }
       }
     ],
     "responses": {


### PR DESCRIPTION
**Changes**
- Added `filter[carrier]` to `GET /shipments` endpoint

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-943
- https://myparcelcombv.atlassian.net/browse/MP-915