### PR TITLE
MP-1189 Added license_number and certificate_number to customs

### DIFF
--- a/specification/examples/PostShipmentRequest.json
+++ b/specification/examples/PostShipmentRequest.json
@@ -94,7 +94,9 @@
       "content_type": "merchandise",
       "invoice_number": "9000",
       "non_delivery": "return",
-      "incoterm": "DDU"
+      "incoterm": "DDU",
+      "license_number": "218532158",
+      "certificate_number": "12122121"
     },
     "register_at": 1504801719
   },

--- a/specification/schemas/BaseCustoms.json
+++ b/specification/schemas/BaseCustoms.json
@@ -34,6 +34,20 @@
       ],
       "example": "DDU",
       "description": "DDU (Delivered Duty Unpaid) or DDP (Delivered Duty Paid)"
+    },
+    "license_number": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "example": "512842382"
+    },
+    "certificate_number": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "example": "2112211"
     }
   }
 }


### PR DESCRIPTION
**Changes**
- Added optional `license_number` and `certificate_number` properties to customs schema.

**Related Issues**
- https://myparcelcombv.atlassian.net/browse/MP-1189