### PR TITLE
Remove carrier_contract_id path parameter from GET /carrier-contracts endpoint

### DIFF
--- a/specification/paths/CarrierContracts.json
+++ b/specification/paths/CarrierContracts.json
@@ -7,9 +7,6 @@
     "description": "This endpoint retrieves carrier contracts.",
     "parameters": [
       {
-        "$ref": "#/components/parameters/path-carrier_contract_id"
-      },
-      {
         "name": "include",
         "in": "query",
         "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>carrier</li><li>owner</li></ul>",


### PR DESCRIPTION
**Changes**
- Removed `carrier_contract_id` path parameter from `GET /carrier-contracts` endpoint

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-1316