### PR TITLE
Make amount of service option price non-required and nullable

### DIFF
--- a/specification/schemas/ServiceOptionPrice.json
+++ b/specification/schemas/ServiceOptionPrice.json
@@ -19,7 +19,24 @@
           "additionalProperties": false,
           "properties": {
             "price": {
-              "$ref": "#/components/schemas/Price"
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "currency"
+              ],
+              "properties": {
+                "amount": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "example": 995,
+                  "description": "Price amount in cents/pence"
+                },
+                "currency": {
+                  "$ref": "#/components/schemas/Currency"
+                }
+              }
             },
             "included": {
               "type": "boolean",


### PR DESCRIPTION
**Changes**
- Made amount of service option price non-required and nullable

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-1285
- https://myparcelcombv.atlassian.net/browse/MP-1282