### PR TITLE
Price amount is no longer required on shipment schemas.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myparcelcom-api-specification",
-  "version": "0.20.7",
+  "version": "0.21.0",
   "description": "Specification of the MyParcel.com API",
   "repository": {
     "type": "git",

--- a/specification/info.json
+++ b/specification/info.json
@@ -11,5 +11,5 @@
     "name": "MyParcel.com general terms and conditions",
     "url": "https://www.myparcel.com/terms"
   },
-  "version": "0.20.7"
+  "version": "0.21.0"
 }

--- a/specification/schemas/Price.json
+++ b/specification/schemas/Price.json
@@ -5,7 +5,6 @@
     },
     {
       "required": [
-        "amount",
         "currency"
       ]
     }

--- a/specification/schemas/ServiceGroup.json
+++ b/specification/schemas/ServiceGroup.json
@@ -60,27 +60,19 @@
               "description": "Volume in liters (dm3)"
             },
             "price": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "currency"
-              ],
-              "properties": {
-                "amount": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 995,
-                  "description": "Price amount in cents/pence"
-                },
-                "currency": {
-                  "$ref": "#/components/schemas/Currency"
-                }
-              }
+              "$ref": "#/components/schemas/Price"
             },
             "step_price": {
-              "$ref": "#/components/schemas/Price"
+              "allOf": [
+                {
+                  "required": [
+                    "amount"
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/Price"
+                }
+              ]
             },
             "step_size": {
               "type": "number",

--- a/specification/schemas/ServiceOptionPrice.json
+++ b/specification/schemas/ServiceOptionPrice.json
@@ -19,24 +19,7 @@
           "additionalProperties": false,
           "properties": {
             "price": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "currency"
-              ],
-              "properties": {
-                "amount": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "example": 995,
-                  "description": "Price amount in cents/pence"
-                },
-                "currency": {
-                  "$ref": "#/components/schemas/Currency"
-                }
-              }
+              "$ref": "#/components/schemas/Price"
             },
             "included": {
               "type": "boolean",

--- a/specification/schemas/ShipmentItem.json
+++ b/specification/schemas/ShipmentItem.json
@@ -17,7 +17,16 @@
       "example": "OnePlus X"
     },
     "item_value": {
-      "$ref": "#/components/schemas/Price"
+      "allOf": [
+        {
+          "required": [
+            "amount"
+          ]
+        },
+        {
+          "$ref": "#/components/schemas/Price"
+        }
+      ]
     },
     "quantity": {
       "type": "number",


### PR DESCRIPTION
**Changes**
- Removed `amount` from required attributes in `price` schema.
- Included `amount` in ShipmentItem `price` object object's array of required attributes.
- Included `amount` in ServiceGroup `step_price` object's array of required attributes.
- Replaced custom `price` schema in ServiceGroup `price` object by the `price` schema.
- Replaced custom `price` schema in ServiceOptionPrice `price` object by the `price` schema.

- [ ] Release 0.21.0