### PR TITLE
:lipstick: moved auth button out of the white bar

### DIFF
--- a/src/myparcelcom.css
+++ b/src/myparcelcom.css
@@ -535,3 +535,17 @@ label[for='system-messages.manage-clientCredentials-checkbox-OAuth2']
 {
   display: none !important;
 }
+
+#swagger-ui .scheme-container {
+  margin: 0;
+  padding: 0;
+  background: #faf7ef;
+  box-shadow: none;
+}
+#swagger-ui .scheme-container .schemes {
+  position: relative;
+}
+#swagger-ui .scheme-container .auth-wrapper {
+  float: right;
+  margin-top: -96px;
+}


### PR DESCRIPTION
The green `Authorize` button was located in a big white bar.
I made it float left to remove the need of this white area.