### PR TITLE
Fixed non json-api complient error object and added descriptions

### DIFF
--- a/specification/schemas/Error.json
+++ b/specification/schemas/Error.json
@@ -2,20 +2,24 @@
   "type": "object",
   "properties": {
     "status": {
-      "type": "number",
-      "example": 422
+      "type": "string",
+      "example": "422",
+      "description": "The HTTP status code applicable to this error."
     },
     "code": {
       "type": "string",
-      "example": "12345"
+      "example": "12345",
+      "description": "Internal MyParcel.com error code."
     },
     "title": {
       "type": "string",
-      "example": "Value is too long"
+      "example": "Value is too long",
+      "description": "A short, human-readable summary of the problem that does not change per occurrence."
     },
     "details": {
       "type": "string",
-      "example": "The description field exceeds the limit of 25 characters."
+      "example": "The description field exceeds the limit of 25 characters.",
+      "description": "A human-readable explanation specific to this occurrence of the problem."
     },
     "source": {
       "type": "object",

--- a/specification/schemas/Error.json
+++ b/specification/schemas/Error.json
@@ -47,8 +47,8 @@
           "example": "ParcelDescription1 exceeds character limit."
         },
         "carrier_status": {
-          "type": "number",
-          "example": 400
+          "type": "string",
+          "example": "400"
         },
         "carrier_rules": {
           "type": "array",


### PR DESCRIPTION
The `status` property should not be a number, but a string according to [the json-api spec](http://jsonapi.org/format/#error-objects).

While I was at it, I added some descriptions for clarification.