### PR TITLE
Feature/mp 1844 carrier statuses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "myparcelcom-api-specification",
-  "version": "0.26.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "myparcelcom-api-specification",
-  "version": "0.27.0",
   "description": "Specification of the MyParcel.com API",
   "repository": {
     "type": "git",

--- a/specification/info.json
+++ b/specification/info.json
@@ -11,5 +11,5 @@
     "name": "MyParcel.com general terms and conditions",
     "url": "https://www.myparcel.com/terms"
   },
-  "version": "0.27.0"
+  "version": "0.28.0"
 }

--- a/specification/schemas/ShipmentStatus.json
+++ b/specification/schemas/ShipmentStatus.json
@@ -12,24 +12,38 @@
         "attributes": {
           "type": "object",
           "required": [
+            "carrier_statuses",
             "created_at"
           ],
           "additionalProperties": false,
           "properties": {
-            "carrier_status_code": {
-              "type": "string",
-              "example": "9001",
-              "description": "The code used by the carrier for this status."
-            },
-            "carrier_status_description": {
-              "type": "string",
-              "example": "Confirmed at destination",
-              "description": "Description of the code used by the carrier."
-            },
-            "carrier_timestamp": {
-              "type": "number",
-              "example": 1504801719,
-              "description": "Unix timestamp when the carrier registered this status."
+            "carrier_statuses": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "description",
+                  "assigned_at"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "example": "9001",
+                    "description": "The code used by the carrier for this status."
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "Confirmed at destination",
+                    "description": "Description of the code used by the carrier."
+                  },
+                  "assigned_at": {
+                    "type": "number",
+                    "example": 1504801719,
+                    "description": "Unix timestamp when the carrier registered this status."
+                  }
+                }
+              }
             },
             "errors": {
               "type": "array",

--- a/specification/schemas/ShipmentStatus.json
+++ b/specification/schemas/ShipmentStatus.json
@@ -12,7 +12,6 @@
         "attributes": {
           "type": "object",
           "required": [
-            "carrier_statuses",
             "created_at"
           ],
           "additionalProperties": false,


### PR DESCRIPTION
[MP-1844](https://myparcelcombv.atlassian.net/browse/MP-1844)

I wanted to make `carrier_statuses` required, but the transformer in our API does not allow for empty arrays. And it is possible a `shipment-statuses` resource does not have any `carrier_statuses`.