### PR TITLE
Remove required links attribute from clients/{client_id} endpoint

### DIFF
--- a/specification/paths/Clients-client_id.json
+++ b/specification/paths/Clients-client_id.json
@@ -25,8 +25,7 @@
             "schema": {
               "type": "object",
               "required": [
-                "data",
-                "links"
+                "data"
               ],
               "properties": {
                 "data": {


### PR DESCRIPTION
Fixed bug where `links` was wrongly marked as required in `clients/{client_id}` endpoint