### PR TITLE
Remove required links from post clients endpoint

### DIFF
--- a/specification/paths/Clients.json
+++ b/specification/paths/Clients.json
@@ -173,8 +173,7 @@
             "schema": {
               "type": "object",
               "required": [
-                "data",
-                "links"
+                "data"
               ],
               "additionalProperties": false,
               "properties": {

--- a/specification/schemas/Client.json
+++ b/specification/schemas/Client.json
@@ -14,7 +14,6 @@
           "required": [
             "name"
           ],
-          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",


### PR DESCRIPTION
**Changes**
- Removed required `links` property from post client response
- Removed `"additionalProperties": false` from Client resource