### PR TITLE
Removed links from service options relationship schema

### DIFF
--- a/specification/paths/ServiceRates-service_rate_id.json
+++ b/specification/paths/ServiceRates-service_rate_id.json
@@ -55,7 +55,6 @@
                                     "required": [
                                       "id",
                                       "type",
-                                      "links",
                                       "meta"
                                     ],
                                     "properties": {

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -81,7 +81,6 @@
                                       "required": [
                                         "id",
                                         "type",
-                                        "links",
                                         "meta"
                                       ],
                                       "properties": {
@@ -247,7 +246,6 @@
                                     "required": [
                                       "id",
                                       "type",
-                                      "links",
                                       "meta"
                                     ],
                                     "properties": {

--- a/specification/schemas/ServiceOptionsRelationship.json
+++ b/specification/schemas/ServiceOptionsRelationship.json
@@ -15,24 +15,7 @@
           {
             "required": [
               "id"
-            ],
-            "properties": {
-              "links": {
-                "readOnly": true,
-                "type": "object",
-                "required": [
-                  "self"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "self": {
-                    "type": "string",
-                    "format": "url",
-                    "example": "$API_HOST/service-options/4c675b1a-516c-4410-abff-d237fd45bcd0"
-                  }
-                }
-              }
-            }
+            ]
           }
         ]
       }


### PR DESCRIPTION
**Related issues**
- None

**Changes**
- Removed the links attribute from service options relationship schema, since our API never actually returns it.