### PR TITLE
:memo: corrected the status includes of the shipment resource

### DIFF
--- a/specification/paths/Shipments-shipment_id-Statuses-shipment_status_id.json
+++ b/specification/paths/Shipments-shipment_id-Statuses-shipment_status_id.json
@@ -22,7 +22,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br> The relationships that can be included are status and shipment.",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br> The relationships that can be included are:<ul><li>`shipment`</li><li>`status`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Shipments-shipment_id.json
+++ b/specification/paths/Shipments-shipment_id.json
@@ -19,7 +19,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`service`</li><li>`contract`</li><li>`service_options`</li><li>`shop`</li><li>`status`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`service`</li><li>`contract`</li><li>`service_options`</li><li>`shipment_status`</li><li>`shipment_status.status`</li><li>`shop`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -16,7 +16,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`service`</li><li>`contract`</li><li>`service_options`</li><li>`shipment_status`</li><li>`shop`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`service`</li><li>`contract`</li><li>`service_options`</li><li>`shipment_status`</li><li>`shipment_status.status`</li><li>`shop`</li></ul>",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
No related issue. This was reported via Marktplaats slack.
---
The `includes` of a shipment resource were not up2date with the API implementation.