### PR TITLE
Feature/mp 2189 use integer instead of number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,9 +1819,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1848,7 +1848,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1874,7 +1874,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1913,7 +1913,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -1962,7 +1962,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1982,12 +1982,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -2052,17 +2052,17 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2086,7 +2086,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2097,18 +2097,18 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -2125,13 +2125,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2208,12 +2208,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -2243,16 +2243,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2270,7 +2270,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2323,17 +2323,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -2344,12 +2344,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -2359,7 +2359,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3104,9 +3104,9 @@
       }
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3597,9 +3597,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
     },
@@ -5251,9 +5251,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.0.tgz",
-      "integrity": "sha512-ZFcQoi4XT2t/NGKByVwmb4iERLtGmQQEFqHNC1PmdauWVZ2y80akkzctghgAftTlc8xpUp+I62nm4Km2q82ajQ=="
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.1.tgz",
+      "integrity": "sha512-KITbEqXkXrjGH12A0lpVZlH3uODFkwUh8d15My1YD4N0PSZDnIiC1iMFT6ryyuJxDYWZh0qezKpPqa5FRowngw=="
     },
     "symbol-observable": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "gulp-replace": "^1.0.0"
   },
   "dependencies": {
-    "swagger-ui-dist": "^3.22.0"
+    "swagger-ui-dist": "^3.22.1"
   }
 }

--- a/specification/paths/Organizations.json
+++ b/specification/paths/Organizations.json
@@ -190,7 +190,7 @@
                 "type": "object",
                 "properties": {
                   "estimated_shipment_volume": {
-                    "type": "number",
+                    "type": "integer",
                     "example": 1000,
                     "description": "Estimated amount of yearly shipments"
                   }

--- a/specification/paths/SuggestAddress.json
+++ b/specification/paths/SuggestAddress.json
@@ -38,7 +38,7 @@
                     "example": "2131 BC"
                   },
                   "street_number": {
-                    "type": "number",
+                    "type": "integer",
                     "example": 679
                   },
                   "street_number_suffix": {
@@ -88,7 +88,7 @@
                         "example": "Hoofdweg"
                       },
                       "street_number": {
-                        "type": "number",
+                        "type": "integer",
                         "example": 679
                       },
                       "street_number_suffix": {

--- a/specification/schemas/BaseAddress.json
+++ b/specification/schemas/BaseAddress.json
@@ -15,7 +15,7 @@
     },
     "street_number": {
       "type": [
-        "number",
+        "integer",
         "null"
       ],
       "example": 221

--- a/specification/schemas/BasePhysicalProperties.json
+++ b/specification/schemas/BasePhysicalProperties.json
@@ -4,7 +4,7 @@
   "properties": {
     "height": {
       "type": [
-        "number",
+        "integer",
         "null"
       ],
       "minimum": 1,
@@ -13,7 +13,7 @@
     },
     "width": {
       "type": [
-        "number",
+        "integer",
         "null"
       ],
       "minimum": 1,
@@ -22,7 +22,7 @@
     },
     "length": {
       "type": [
-        "number",
+        "integer",
         "null"
       ],
       "minimum": 1,
@@ -39,7 +39,7 @@
       "description": "Volume in liters. (dm3)"
     },
     "weight": {
-      "type": "number",
+      "type": "integer",
       "minimum": 1,
       "example": 5000,
       "description": "Weight in grams."

--- a/specification/schemas/BaseShipmentItem.json
+++ b/specification/schemas/BaseShipmentItem.json
@@ -26,7 +26,7 @@
       ]
     },
     "quantity": {
-      "type": "number",
+      "type": "integer",
       "example": 2
     },
     "hs_code": {
@@ -40,11 +40,11 @@
     },
     "item_weight": {
       "type": [
-        "number",
+        "integer",
         "null"
       ],
       "example": 135,
-      "description": "Weight of a single item within item resource. Should be multiplied by quantity to get total weight."
+      "description": "Weight in grams of a single item within item resource. Should be multiplied by quantity to get total weight."
     },
     "origin_country_code": {
       "oneOf": [

--- a/specification/schemas/Hook.json
+++ b/specification/schemas/Hook.json
@@ -26,7 +26,7 @@
               "example": "DPD Next Day for medium packages"
             },
             "order": {
-              "type": "number",
+              "type": "integer",
               "example": 3,
               "description": "Priority of this hook, lower value means it is triggered first."
             },

--- a/specification/schemas/Invoice.json
+++ b/specification/schemas/Invoice.json
@@ -22,7 +22,7 @@
             },
             "billing_term_start_at": {
               "type": [
-                "number",
+                "integer",
                 "null"
               ],
               "example": 1517443200,
@@ -30,7 +30,7 @@
             },
             "billing_term_end_at": {
               "type": [
-                "number",
+                "integer",
                 "null"
               ],
               "example": 1519862399,

--- a/specification/schemas/PaginationMeta.json
+++ b/specification/schemas/PaginationMeta.json
@@ -7,11 +7,11 @@
   "additionalProperties": false,
   "properties": {
     "total_pages": {
-      "type": "number",
+      "type": "integer",
       "example": 13
     },
     "total_records": {
-      "type": "number",
+      "type": "integer",
       "example": 373
     }
   }

--- a/specification/schemas/PatchHook.json
+++ b/specification/schemas/PatchHook.json
@@ -26,7 +26,7 @@
           "example": "DPD Next Day for medium packages"
         },
         "order": {
-          "type": "number",
+          "type": "integer",
           "example": 3,
           "description": "Priority of this hook, lower value means it is triggered first."
         },

--- a/specification/schemas/PatchPayment.json
+++ b/specification/schemas/PatchPayment.json
@@ -15,7 +15,7 @@
           "properties": {
             "paid_at": {
               "type": [
-                "number",
+                "integer",
                 "null"
               ],
               "example": 1504801719,

--- a/specification/schemas/PatchServiceRate.json
+++ b/specification/schemas/PatchServiceRate.json
@@ -14,33 +14,33 @@
           "additionalProperties": false,
           "properties": {
             "weight_min": {
-              "type": "number",
+              "type": "integer",
               "example": 0,
               "description": "Weight in grams."
             },
             "weight_max": {
-              "type": "number",
+              "type": "integer",
               "example": 2000,
               "description": "Weight in grams."
             },
             "length_max": {
-              "type": "number",
+              "type": "integer",
               "example": 300,
               "description": "Length in mm."
             },
             "width_max": {
-              "type": "number",
+              "type": "integer",
               "example": 200,
               "description": "Width in mm."
             },
             "height_max": {
-              "type": "number",
+              "type": "integer",
               "example": 200,
               "description": "Height in mm."
             },
             "volume_max": {
               "type": "number",
-              "example": 12,
+              "example": 12.5,
               "description": "Volume in liters. (dm3)"
             },
             "price": {

--- a/specification/schemas/Payment.json
+++ b/specification/schemas/Payment.json
@@ -15,7 +15,7 @@
             },
             "paid_at": {
               "type": [
-                "number",
+                "integer",
                 "null"
               ],
               "example": 1504801719,

--- a/specification/schemas/PriceAmount.json
+++ b/specification/schemas/PriceAmount.json
@@ -1,5 +1,5 @@
 {
-  "type": "number",
+  "type": "integer",
   "example": 995,
   "description": "Price amount in cents/pence."
 }

--- a/specification/schemas/Service.json
+++ b/specification/schemas/Service.json
@@ -60,11 +60,11 @@
               "additionalProperties": false,
               "properties": {
                 "min": {
-                  "type": "number",
+                  "type": "integer",
                   "example": 1
                 },
                 "max": {
-                  "type": "number",
+                  "type": "integer",
                   "example": 3
                 }
               }

--- a/specification/schemas/ServiceRate.json
+++ b/specification/schemas/ServiceRate.json
@@ -18,33 +18,33 @@
           ],
           "properties": {
             "weight_min": {
-              "type": "number",
+              "type": "integer",
               "example": 0,
               "description": "Weight in grams."
             },
             "weight_max": {
-              "type": "number",
+              "type": "integer",
               "example": 2000,
               "description": "Weight in grams."
             },
             "length_max": {
-              "type": "number",
+              "type": "integer",
               "example": 300,
               "description": "Length in mm."
             },
             "width_max": {
-              "type": "number",
+              "type": "integer",
               "example": 200,
               "description": "Width in mm."
             },
             "height_max": {
-              "type": "number",
+              "type": "integer",
               "example": 200,
               "description": "Height in mm."
             },
             "volume_max": {
               "type": "number",
-              "example": 12,
+              "example": 12.5,
               "description": "Volume in liters. (dm3)"
             },
             "price": {

--- a/specification/schemas/ShipmentItem.json
+++ b/specification/schemas/ShipmentItem.json
@@ -29,7 +29,7 @@
       ]
     },
     "quantity": {
-      "type": "number",
+      "type": "integer",
       "example": 2
     },
     "hs_code": {
@@ -43,11 +43,11 @@
     },
     "item_weight": {
       "type": [
-        "number",
+        "integer",
         "null"
       ],
       "example": 135,
-      "description": "Weight of a single item within item resource. Should be multiplied by quantity to get total weight."
+      "description": "Weight in grams of a single item within item resource. Should be multiplied by quantity to get total weight."
     }
   }
 }

--- a/specification/schemas/ShipmentStatus.json
+++ b/specification/schemas/ShipmentStatus.json
@@ -39,7 +39,7 @@
                     "description": "Description of the code used by the carrier."
                   },
                   "assigned_at": {
-                    "type": "number",
+                    "type": "integer",
                     "example": 1504801719,
                     "description": "Unix timestamp when the carrier registered this status."
                   }
@@ -53,7 +53,7 @@
               }
             },
             "created_at": {
-              "type": "number",
+              "type": "integer",
               "example": 1504801719,
               "description": "Unix timestamp when the status was created."
             }

--- a/specification/schemas/Timestamp.json
+++ b/specification/schemas/Timestamp.json
@@ -1,6 +1,6 @@
 {
   "readOnly": true,
-  "type": "number",
+  "type": "integer",
   "example": 1504801719,
   "description": "Unix timestamp."
 }


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-2189
---
Instead of only the weight, I changed all `number` which may not be a float to `integer`.

:tada: Running the API tests with this new spec is successful.
:ok_hand: Creating a shipment with weight `0.350` now results in a `400` spec error with:
```
{
    "property": "data.attributes.physical_properties.weight",
    "pointer": "/data/attributes/physical_properties/weight",
    "message": "Double value found, but an integer is required",
    "constraint": "type",
    "context": 1
}
```