### PR TITLE
MP-2451 Added volumetric_weight to physical_properties schema.

### DIFF
--- a/specification/schemas/BasePhysicalProperties.json
+++ b/specification/schemas/BasePhysicalProperties.json
@@ -43,6 +43,16 @@
       "minimum": 1,
       "example": 5000,
       "description": "Weight in grams."
+    },
+    "volumetric_weight": {
+      "readOnly": true,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1,
+      "example": 4500,
+      "description": "Volumetric weight in grams. Calculated by the API by multiplying shipment dimensions (if present) and dividing them by 5000: (height in mm * length in mm * width in mm) / 5000."
     }
   }
 }


### PR DESCRIPTION
**Related issues**
- [MP-2451](https://myparcelcombv.atlassian.net/browse/MP-2451) (Subtask)
- [MP-2409](https://myparcelcombv.atlassian.net/browse/MP-2409) (Story)

**Notes**
In case you were wondering about the formula being different than the one in the Epic, the one in the epic results in a volumetric weight in KG. Since we use grams as the unit for all of our weight properties, we can divide the volume (in mm3) by 5000 instead of 5000000 to get the volumetric weight in grams instead of KG.
