### PR TITLE
Removed additional properties false from integrationsRelationship schema.

### DIFF
--- a/specification/schemas/IntegrationsRelationship.json
+++ b/specification/schemas/IntegrationsRelationship.json
@@ -3,7 +3,6 @@
   "required": [
     "data"
   ],
-  "additionalProperties": false,
   "properties": {
     "data": {
       "type": "array",


### PR DESCRIPTION
**Changes**
- Removed additionalProperties: false from the integrationsRelationship schema. It was causing problems when trying to add links to the response of the GET `/shops/{shop_id}/relationships/integrations` endpoint. 