### PR TITLE
🐛 Fixed wrong example self link on shipment surcharges

### DIFF
--- a/specification/schemas/ShipmentSurcharge.json
+++ b/specification/schemas/ShipmentSurcharge.json
@@ -66,7 +66,7 @@
             "self": {
               "type": "string",
               "format": "url",
-              "example": "$API_HOST/shipments/7b808eee-bf1c-40cd-98f2-3c335a06417e/surcharges/385446dg-34e1-42a1-n832-bcc209450ea9"
+              "example": "$API_HOST/shipment-surcharges/385446dg-34e1-42a1-n832-bcc209450ea9"
             }
           }
         }


### PR DESCRIPTION
**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-2730
