### PR TITLE
♻️ Nullable system-message resource_type

### DIFF
--- a/specification/schemas/SystemMessage.json
+++ b/specification/schemas/SystemMessage.json
@@ -24,12 +24,19 @@
               "example": "info"
             },
             "resource_type": {
-              "type": "string",
-              "enum": [
-                "shipments",
-                "carriers"
-              ],
-              "example": "shipments"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "shipments",
+                    "carriers"
+                  ],
+                  "example": "shipments",
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "content": {
               "type": "string",


### PR DESCRIPTION
Patching to `null` was already possible. Now we can also post `null`.