### PR TITLE
MP-3067 ✨ Added import service sheet endpoint

### DIFF
--- a/specification/paths.json
+++ b/specification/paths.json
@@ -179,6 +179,9 @@
   "/users/{user_id}": {
     "$ref": "./paths/Users-user_id.json"
   },
+  "/import-service-rates": {
+    "$ref": "./paths/ImportServiceRates.json"
+  },
   "/suggest-address": {
     "$ref": "./paths/SuggestAddress.json"
   },

--- a/specification/paths/ImportServiceRates.json
+++ b/specification/paths/ImportServiceRates.json
@@ -1,0 +1,57 @@
+{
+  "post": {
+    "tags": [
+      "RPC"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "contracts.manage"
+        ]
+      }
+    ],
+    "summary": "Import service rates.",
+    "description": "This endpoint allows a user to alter the service-rates of a contract by uploading a CSV.",
+    "requestBody": {
+      "description": "The contract id to be targeted and the CSV data containing services with rates to import.",
+      "required": true,
+      "content": {
+        "application/json": {
+          "schema": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": [
+                  "contract_id",
+                  "csv"
+                ],
+                "properties": {
+                  "contract_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$",
+                    "example": "2cb32706-5762-4b96-9212-327e6afaeeff"
+                  },
+                  "csv": {
+                    "type": "string",
+                    "description": "Base64 encoded CSV data",
+                    "example": "TWFydGluLE5pY2ssVGhvbWFzLFlvYW4="
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "204": {
+        "description": "The service-rates have been added to the contract."
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-3067
---
After discussing the usage of this endpoint, we will limit it to alter the service-rates for 1 contract. Therefore we only need a `contract_id` and the CSV `data`.

At the moment, our broker has 28 contracts in total. The front-end can still work with a broker/organization filter to select the contract, or even fire 4 requests to update all 4 tiers.