### PR TITLE
💹 Added /analytics/on-time-delivery path

### DIFF
--- a/specification/paths.json
+++ b/specification/paths.json
@@ -202,5 +202,8 @@
   },
   "/void-shipment": {
     "$ref": "./paths/VoidShipment.json"
+  },
+  "/analytics/on-time-delivery/{interval}": {
+    "$ref": "./paths/Analytics-on-time-delivery.json"
   }
 }

--- a/specification/paths/Analytics-on-time-delivery.json
+++ b/specification/paths/Analytics-on-time-delivery.json
@@ -1,0 +1,91 @@
+{
+  "get": {
+    "tags": [
+      "Analytics"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      }
+    ],
+    "summary": "Get analytics report for delivered shipments on time.",
+    "description": "This endpoint retrieves the rate by which shipments are successfully delivered on time on intervals.",
+    "parameters": [
+      {
+        "name": "interval",
+        "in": "path",
+        "description": "Interval by which to arrange the dataset.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "month",
+          "enum": [
+            "month"
+          ]
+        }
+      },
+      {
+        "name": "filter[date_from]",
+        "in": "query",
+        "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments created at >= this date will be in the response.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "filter[date_to]",
+        "in": "query",
+        "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments created at <= this date will be in the response.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "filter[shop]",
+        "in": "query",
+        "description": "Comma separated string of shop ids to filter by.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "filter[organization]",
+        "in": "query",
+        "description": "Comma separated string of organization ids to filter by.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "filter[carrier]",
+        "in": "query",
+        "description": "Comma separated string of carrier ids to filter by.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Retrieved the analytics data in timeseries.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "properties": {
+                "data": {
+                  "$ref": "#/components/schemas/Analytics"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -358,5 +358,8 @@
   },
   "UserRelationship": {
     "$ref": "./schemas/UserRelationship.json"
+  },
+  "Analytics": {
+    "$ref": "./schemas/Analytics.json"
   }
 }

--- a/specification/schemas/Analytics.json
+++ b/specification/schemas/Analytics.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "unit_type": {
+      "type": "string",
+      "example": "percentage",
+      "enum": [
+        "percentage"
+      ]
+    },
+    "labels": {
+      "type": "array",
+      "description": "List of all chart labels on the X axis",
+      "items": {
+        "type": "string",
+        "example": "January"
+      }
+    },
+    "datasets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "example": "Delivery < 1 day"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "example": "93.56"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Changes
- Introduced new endpoint for analytics (on time delivery stats)
- Introduced new schema for Analytics datasets