### PR TITLE
MP-3280 🔥 removed users:manage scope from user id endpoints

### DIFF
--- a/specification/paths/Users-user_id.json
+++ b/specification/paths/Users-user_id.json
@@ -11,7 +11,6 @@
     "security": [
       {
         "OAuth2": [
-          "users.manage"
         ]
       }
     ],
@@ -62,7 +61,6 @@
     "security": [
       {
         "OAuth2": [
-          "users.manage"
         ]
       }
     ],


### PR DESCRIPTION
Otherwise all users need to get `users.manage` on their user resource.