### PR TITLE
♻️ Added city to pickup-dropoff parameters

### DIFF
--- a/specification/parameters.json
+++ b/specification/parameters.json
@@ -101,6 +101,9 @@
   "path-user_id": {
     "$ref": "./parameters/path-user_id.json"
   },
+  "query-city": {
+    "$ref": "./parameters/query-city.json"
+  },
   "query-street": {
     "$ref": "./parameters/query-street.json"
   },

--- a/specification/parameters/path-postal_code.json
+++ b/specification/parameters/path-postal_code.json
@@ -1,7 +1,7 @@
 {
   "name": "postal_code",
   "in": "path",
-  "description": "Postal code.",
+  "description": "Postal code of the address to search nearby.",
   "required": true,
   "schema": {
     "type": "string"

--- a/specification/parameters/query-city.json
+++ b/specification/parameters/query-city.json
@@ -1,0 +1,8 @@
+{
+  "name": "city",
+  "in": "query",
+  "description": "City of the address to search nearby.",
+  "schema": {
+    "type": "string"
+  }
+}

--- a/specification/parameters/query-street.json
+++ b/specification/parameters/query-street.json
@@ -1,7 +1,7 @@
 {
   "name": "street",
   "in": "query",
-  "description": "Name of the street.",
+  "description": "Street name of the address to search nearby.",
   "schema": {
     "type": "string"
   }

--- a/specification/parameters/query-street_number.json
+++ b/specification/parameters/query-street_number.json
@@ -1,7 +1,7 @@
 {
   "name": "street_number",
   "in": "query",
-  "description": "The street or house number of the address.",
+  "description": "House number of the address to search nearby.",
   "schema": {
     "type": "string"
   }

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -113,9 +113,6 @@
   "/regions/{region_id}": {
     "$ref": "./paths/Regions-region_id.json"
   },
-  "/registered-shipments": {
-    "$ref": "./paths/RegisteredShipments.json"
-  },
   "/reports": {
     "$ref": "./paths/Reports.json"
   },
@@ -148,6 +145,9 @@
   },
   "/shipments": {
     "$ref": "./paths/Shipments.json"
+  },
+  "/registered-shipments": {
+    "$ref": "./paths/RegisteredShipments.json"
   },
   "/shipments/{shipment_id}": {
     "$ref": "./paths/Shipments-shipment_id.json"

--- a/specification/paths/Carriers-carrier_id-PickupDropoffLocations-country_code-postal_code.json
+++ b/specification/paths/Carriers-carrier_id-PickupDropoffLocations-country_code-postal_code.json
@@ -21,7 +21,7 @@
       }
     ],
     "summary": "Get all the locations from a carrier.",
-    "description": "This endpoint retrieves pick-up and drop-off locations offered by the supplied carrier. Locations of the type `pick-up` can be used with services offering this as their `delivery_method`. Locations of the type `drop-off` can be used with services offering this as their `handover_method`.",
+    "description": "This endpoint retrieves pick-up and drop-off locations offered by the supplied carrier.<ul><li>Locations of the type `pick-up` can be used with services offering this as their `delivery_method`.</li><li>Locations of the type `drop-off` can be used with services offering this as their `handover_method`.</li></ul>",
     "parameters": [
       {
         "$ref": "#/components/parameters/query-street"
@@ -30,9 +30,12 @@
         "$ref": "#/components/parameters/query-street_number"
       },
       {
+        "$ref": "#/components/parameters/query-city"
+      },
+      {
         "name": "filter[categories]",
         "in": "query",
-        "description": "Comma separated list of what kind of locations to return. Possible values are:<ul><li>`pick-up`</li><li>`drop-off`</li></ul>",
+        "description": "Comma separated list of location categories to return. Possible options are:<ul><li>`pick-up`</li><li>`drop-off`</li></ul>",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
City is required for the DPD Parcelshopfinder to be able to return results.
Also moved `POST /registered-shipments` endpoint to show below regular `POST /shipments` endpoint in the sidebar.