### PR TITLE
Added Report file download path

### DIFF
--- a/specification/parameters/header-files.json
+++ b/specification/parameters/header-files.json
@@ -1,7 +1,7 @@
 {
   "name": "Accept",
   "in": "header",
-  "description": "You can set the accept header to either receive a JSON response, or the files in given format. Possible options are: <ul><li>`application/vnd.api+json`</li><li>`application/pdf`</li><li>`application/zpl`</li><li>`image/png`</li><li>`text/csv`</li></ul>",
+  "description": "You must set the accept header to retrieve the file in the given format. Possible options are: <ul><li>`application/vnd.api+json`</li><li>`application/pdf`</li><li>`application/zpl`</li><li>`image/png`</li><li>`text/csv`</li></ul>",
   "required": true,
   "schema": {
     "type": "string",

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -119,6 +119,9 @@
   "/reports/{report_id}": {
     "$ref": "./paths/Reports-report_id.json"
   },
+  "/reports/{report_id}/files/{file_id}": {
+    "$ref": "./paths/Reports-report_id-Files-file_id.json"
+  },
   "/scopes": {
     "$ref": "./paths/Scopes.json"
   },

--- a/specification/paths/Reports-report_id-Files-file_id.json
+++ b/specification/paths/Reports-report_id-Files-file_id.json
@@ -1,0 +1,51 @@
+{
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-report_id"
+    },
+    {
+      "$ref": "#/components/parameters/path-file_id"
+    }
+  ],
+  "get": {
+    "tags": [
+      "Reports"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      }
+    ],
+    "summary": "Get file related to a report.",
+    "description": "This endpoint retrieves a file for the supplied report. All successfully completed reports will have attached reports file.",
+    "parameters": [
+      {
+        "name": "Accept",
+        "in": "header",
+        "description": "You can set the accept header to either receive a JSON response, or the files in given format. Possible options are: <ul><li>`text/csv`</li></ul>",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "text/csv"
+          ]
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Retrieved the file.",
+        "content": {
+          "text/csv": {
+            "schema": {
+              "type": "string",
+              "description": "Contents of the CSV file"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/paths/Reports-report_id-Files-file_id.json
+++ b/specification/paths/Reports-report_id-Files-file_id.json
@@ -18,13 +18,13 @@
         ]
       }
     ],
-    "summary": "Get file related to a report.",
-    "description": "This endpoint retrieves a file for the supplied report. All successfully completed reports will have attached reports file.",
+    "summary": "Get a file related to a report.",
+    "description": "This endpoint retrieves the file of the supplied report. All successfully completed reports will have an attached CSV file.",
     "parameters": [
       {
         "name": "Accept",
         "in": "header",
-        "description": "You can set the accept header to either receive a JSON response, or the files in given format. Possible options are: <ul><li>`text/csv`</li></ul>",
+        "description": "You must set the accept header to retrieve the file in the given format. Possible options are: <ul><li>`text/csv`</li></ul>",
         "required": true,
         "schema": {
           "type": "string",
@@ -41,7 +41,7 @@
           "text/csv": {
             "schema": {
               "type": "string",
-              "description": "Contents of the CSV file"
+              "description": "Base64 encoded contents of the CSV file."
             }
           }
         }


### PR DESCRIPTION
# Changes
- Added new path /reports/{report_id}/files/{file_id} endpoint
- Endpoint accepts header is `text/csv` only since it is the only supported format