### PR TITLE
MP-3943 🔒 Allow shipments.manage on hook related get endpoints

### DIFF
--- a/specification/paths/HookLogs-hook_log_id.json
+++ b/specification/paths/HookLogs-hook_log_id.json
@@ -11,7 +11,8 @@
     "security": [
       {
         "OAuth2": [
-          "experimental"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/paths/Hooks-hook_id-logs.json
+++ b/specification/paths/Hooks-hook_id-logs.json
@@ -11,7 +11,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/paths/Hooks-hook_id.json
+++ b/specification/paths/Hooks-hook_id.json
@@ -11,7 +11,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],
@@ -56,7 +57,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],
@@ -121,7 +123,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/paths/Hooks.json
+++ b/specification/paths/Hooks.json
@@ -6,7 +6,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],
@@ -108,7 +109,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],


### PR DESCRIPTION
Hooks and HookLogs should be accessible when you are allowed to manage shipments.