### PR TITLE
♻️ Make shop-integration meta not required

### DIFF
--- a/specification/schemas/IntegrationsRelationship.json
+++ b/specification/schemas/IntegrationsRelationship.json
@@ -12,9 +12,6 @@
             "$ref": "#/components/schemas/MinimalIntegration"
           },
           {
-            "required": [
-              "meta"
-            ],
             "properties": {
               "meta": {
                 "type": "object",


### PR DESCRIPTION
It works fine when posted without `meta`.