### PR TITLE
⏪ Remove has_active_contract filter on carriers endpoint

### DIFF
--- a/specification/paths/Carriers.json
+++ b/specification/paths/Carriers.json
@@ -11,16 +11,6 @@
     ],
     "summary": "Get all available carriers for your API client.",
     "description": "This endpoint retrieves all carriers available to your API client. The availability of carriers depends on the broker your client is connected to.",
-    "parameters": [
-      {
-        "name": "filter[has_active_contract]",
-        "in": "query",
-        "description": "Boolean value.<ul><li>`true` Only carriers with active contract associations.</li><li>`false` Only carriers without active contract associations.</li></ul>",
-        "schema": {
-          "type": "boolean"
-        }
-      }
-    ],
     "responses": {
       "200": {
         "description": "Retrieved the carriers.",


### PR DESCRIPTION
This is actually not needed to achieve "Service filter should only show carriers available to organization".
And annoying to implement in the API, so let's revert this while it's still only in develop.