### PR TITLE
♻️ Add status cancelled

### DIFF
--- a/specification/schemas/Status.json
+++ b/specification/schemas/Status.json
@@ -51,6 +51,7 @@
             "level": {
               "type": "string",
               "enum": [
+                "cancelled",
                 "failed",
                 "in-progress",
                 "pending",


### PR DESCRIPTION
This status has been introduced together with `shipment-voided` but has never been listed.