### PR TITLE
✨ Add collo_number and colli to shipment resource

### DIFF
--- a/specification/parameters/query-shipments-include.json
+++ b/specification/parameters/query-shipments-include.json
@@ -1,7 +1,7 @@
 {
   "name": "include",
   "in": "query",
-  "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`consolidation_shipment`</li><li>`contract`</li><li>`files`</li><li>`hook_logs`</li><li>`liability_coverage`</li><li>`service`</li><li>`service.carrier`</li><li>`service_options`</li><li>`shipment_status`</li><li>`shipment_status.status`</li><li>`shop`</li><li>`shop.organization`</li><li>`shipment_surcharges`</li></ul>",
+  "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`colli`</li><li>`consolidation_shipment`</li><li>`contract`</li><li>`files`</li><li>`hook_logs`</li><li>`liability_coverage`</li><li>`service`</li><li>`service.carrier`</li><li>`service_options`</li><li>`shipment_status`</li><li>`shipment_status.status`</li><li>`shop`</li><li>`shop.organization`</li><li>`shipment_surcharges`</li></ul>",
   "schema": {
     "type": "string"
   }

--- a/specification/paths/RegisterMultiColliShipment.json
+++ b/specification/paths/RegisterMultiColliShipment.json
@@ -147,8 +147,38 @@
       }
     },
     "responses": {
-      "204": {
-        "description": "The multi-colli shipment has been created."
+      "201": {
+        "description": "The multi-colli shipment is created.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "properties": {
+                "data": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ShipmentResponse"
+                    },
+                    {
+                      "properties": {
+                        "relationships": {
+                          "required": [
+                            "colli",
+                            "contract",
+                            "service"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -314,6 +314,9 @@
   "Shipment": {
     "$ref": "./schemas/Shipment.json"
   },
+  "ShipmentColliRelationship": {
+    "$ref": "./schemas/ShipmentColliRelationship.json"
+  },
   "ShipmentFilesRelationship": {
     "$ref": "./schemas/ShipmentFilesRelationship.json"
   },

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -205,12 +205,28 @@
                   "type": "null"
                 }
               ]
+            },
+            "collo_number": {
+              "readOnly": true,
+              "type": "string",
+              "example": "1",
+              "description": "Sequence number when this shipment is part of a multi-colli shipment."
             }
           }
         },
         "relationships": {
           "type": "object",
           "properties": {
+            "colli": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ShipmentRelationship"
+                },
+                {
+                  "readOnly": true
+                }
+              ]
+            },
             "contract": {
               "oneOf": [
                 {

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -220,7 +220,7 @@
             "colli": {
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/ShipmentRelationship"
+                  "$ref": "#/components/schemas/ShipmentColliRelationship"
                 },
                 {
                   "readOnly": true

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -208,8 +208,8 @@
             },
             "collo_number": {
               "readOnly": true,
-              "type": "string",
-              "example": "1",
+              "type": "integer",
+              "example": 1,
               "description": "Sequence number when this shipment is part of a multi-colli shipment."
             }
           }

--- a/specification/schemas/ShipmentColliRelationship.json
+++ b/specification/schemas/ShipmentColliRelationship.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/Shipment"
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-3613
- Add read-only `collo_number` to shipment attributes.
- Add read-only `colli` to shipment relationships and includes list.
- Update response of `/register-multi-colli-shipment` RPC endpoint.