### PR TITLE
MP-4229 ✨ Add meta with collo details to multi-colli response

### DIFF
--- a/root.json
+++ b/root.json
@@ -27,7 +27,7 @@
         "scheme": "Bearer",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "$AUTH_HOST",
+            "tokenUrl": "$AUTH_HOST/access-token",
             "scopes": {
               "addresses.suggest": "Retrieve address suggestions.",
               "broker.member": "Retrieve broker related resources and create organizations for that broker.",

--- a/specification/paths/RegisterMultiColliShipment.json
+++ b/specification/paths/RegisterMultiColliShipment.json
@@ -174,6 +174,57 @@
                       }
                     }
                   ]
+                },
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "colli": {
+                      "type": "array",
+                      "description": "An array of objects holding attributes of all created collo shipments",
+                      "items": {
+                        "properties": {
+                          "collo_number": {
+                            "$ref": "#/components/schemas/ColloNumber"
+                          },
+                          "barcode": {
+                            "$ref": "#/components/schemas/Barcode"
+                          },
+                          "tracking_code": {
+                            "$ref": "#/components/schemas/TrackingCode"
+                          },
+                          "tracking_url": {
+                            "$ref": "#/components/schemas/TrackingUrl"
+                          },
+                          "files": {
+                            "type": "array",
+                            "description": "An array of objects holding the attributes and contents (Base64 encoded) of created files",
+                            "items": {
+                              "allOf": [
+                                {
+                                  "$ref": "#/components/schemas/FileFormat"
+                                },
+                                {
+                                  "required": [
+                                    "document_type",
+                                    "contents"
+                                  ],
+                                  "properties": {
+                                    "document_type": {
+                                      "$ref": "#/components/schemas/DocumentType"
+                                    },
+                                    "contents": {
+                                      "type": "string",
+                                      "description": "Base64 encoded file data"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/specification/paths/RegisterMultiColliShipment.json
+++ b/specification/paths/RegisterMultiColliShipment.json
@@ -150,7 +150,7 @@
       "201": {
         "description": "The multi-colli shipment is created.",
         "content": {
-          "application/vnd.api+json": {
+          "application/json": {
             "schema": {
               "type": "object",
               "required": [
@@ -169,62 +169,66 @@
                             "colli",
                             "contract",
                             "service"
-                          ]
-                        }
-                      }
-                    }
-                  ]
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "colli": {
-                      "type": "array",
-                      "description": "An array of objects holding attributes of all created collo shipments",
-                      "items": {
-                        "properties": {
-                          "collo_number": {
-                            "$ref": "#/components/schemas/ColloNumber"
-                          },
-                          "barcode": {
-                            "$ref": "#/components/schemas/Barcode"
-                          },
-                          "tracking_code": {
-                            "$ref": "#/components/schemas/TrackingCode"
-                          },
-                          "tracking_url": {
-                            "$ref": "#/components/schemas/TrackingUrl"
-                          },
-                          "files": {
-                            "type": "array",
-                            "description": "An array of objects holding the attributes and contents (Base64 encoded) of created files",
-                            "items": {
-                              "allOf": [
-                                {
-                                  "$ref": "#/components/schemas/FileFormat"
-                                },
-                                {
-                                  "required": [
-                                    "document_type",
-                                    "contents"
-                                  ],
-                                  "properties": {
-                                    "document_type": {
-                                      "$ref": "#/components/schemas/DocumentType"
-                                    },
-                                    "contents": {
-                                      "type": "string",
-                                      "description": "Base64 encoded file data"
+                          ],
+                          "properties": {
+                            "colli": {
+                              "properties": {
+                                "data": {
+                                  "items": {
+                                    "properties": {
+                                      "meta": {
+                                        "type": "object",
+                                        "properties": {
+                                          "collo_number": {
+                                            "$ref": "#/components/schemas/ColloNumber"
+                                          },
+                                          "barcode": {
+                                            "$ref": "#/components/schemas/Barcode"
+                                          },
+                                          "tracking_code": {
+                                            "$ref": "#/components/schemas/TrackingCode"
+                                          },
+                                          "tracking_url": {
+                                            "$ref": "#/components/schemas/TrackingUrl"
+                                          },
+                                          "files": {
+                                            "type": "array",
+                                            "description": "An array of objects holding the attributes and contents (Base64 encoded) of created files",
+                                            "items": {
+                                              "allOf": [
+                                                {
+                                                  "$ref": "#/components/schemas/FileFormat"
+                                                },
+                                                {
+                                                  "required": [
+                                                    "document_type",
+                                                    "contents"
+                                                  ],
+                                                  "properties": {
+                                                    "document_type": {
+                                                      "$ref": "#/components/schemas/DocumentType"
+                                                    },
+                                                    "contents": {
+                                                      "type": "string",
+                                                      "description": "Base64 encoded file data"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      }
                                     }
                                   }
                                 }
-                              ]
+                              }
                             }
                           }
                         }
                       }
                     }
-                  }
+                  ]
                 }
               }
             }

--- a/specification/paths/RegisteredShipments.json
+++ b/specification/paths/RegisteredShipments.json
@@ -105,7 +105,7 @@
                   "properties": {
                     "files": {
                       "type": "array",
-                      "description": "An array of objects holding the attributes and contents (Base64 encoded) of attached files",
+                      "description": "An array of objects holding the attributes and contents (Base64 encoded) of created files",
                       "items": {
                         "allOf": [
                           {

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -2,6 +2,9 @@
   "Address": {
     "$ref": "./schemas/Address.json"
   },
+  "Barcode": {
+    "$ref": "./schemas/Barcode.json"
+  },
   "BaseAddress": {
     "$ref": "./schemas/BaseAddress.json"
   },
@@ -37,6 +40,9 @@
   },
   "Client": {
     "$ref": "./schemas/Client.json"
+  },
+  "ColloNumber": {
+    "$ref": "./schemas/ColloNumber.json"
   },
   "CombinedFile": {
     "$ref": "./schemas/CombinedFile.json"
@@ -367,6 +373,12 @@
   },
   "Timestamp": {
     "$ref": "./schemas/Timestamp.json"
+  },
+  "TrackingCode": {
+    "$ref": "./schemas/TrackingCode.json"
+  },
+  "TrackingUrl": {
+    "$ref": "./schemas/TrackingUrl.json"
   },
   "User": {
     "$ref": "./schemas/User.json"

--- a/specification/schemas/Barcode.json
+++ b/specification/schemas/Barcode.json
@@ -1,0 +1,6 @@
+{
+  "readOnly": true,
+  "type": "string",
+  "example": "3SABCD0123456789",
+  "description": "Textual representation of the barcode present on the label."
+}

--- a/specification/schemas/ColloNumber.json
+++ b/specification/schemas/ColloNumber.json
@@ -1,0 +1,6 @@
+{
+  "readOnly": true,
+  "type": "integer",
+  "example": 1,
+  "description": "Sequence number when this shipment is part of a multi-colli shipment."
+}

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -98,22 +98,13 @@
               ]
             },
             "barcode": {
-              "readOnly": true,
-              "type": "string",
-              "example": "3SABCD0123456789",
-              "description": "Textual representation of the barcode present on the label."
+              "$ref": "#/components/schemas/Barcode"
             },
             "tracking_code": {
-              "readOnly": true,
-              "type": "string",
-              "example": "3SABCD0123456789",
-              "description": "Code used to request tracking status from the carrier. This is not necessarily the same as the shipment barcode."
+              "$ref": "#/components/schemas/TrackingCode"
             },
             "tracking_url": {
-              "readOnly": true,
-              "type": "string",
-              "example": "https://tracker.carrier.com/3SABCD0123456789",
-              "description": "URL used to view tracking status updates."
+              "$ref": "#/components/schemas/TrackingUrl"
             },
             "sync_active": {
               "readOnly": true,
@@ -207,10 +198,7 @@
               ]
             },
             "collo_number": {
-              "readOnly": true,
-              "type": "integer",
-              "example": 1,
-              "description": "Sequence number when this shipment is part of a multi-colli shipment."
+              "$ref": "#/components/schemas/ColloNumber"
             }
           }
         },

--- a/specification/schemas/ShipmentColliRelationship.json
+++ b/specification/schemas/ShipmentColliRelationship.json
@@ -8,7 +8,7 @@
     "data": {
       "type": "array",
       "items": {
-        "$ref": "#/components/schemas/Shipment"
+        "$ref": "#/components/schemas/ShipmentResource"
       }
     }
   }

--- a/specification/schemas/TrackingCode.json
+++ b/specification/schemas/TrackingCode.json
@@ -1,0 +1,6 @@
+{
+  "readOnly": true,
+  "type": "string",
+  "example": "3SABCD0123456789",
+  "description": "Code used to request tracking status from the carrier. This is not necessarily the same as the shipment barcode."
+}

--- a/specification/schemas/TrackingUrl.json
+++ b/specification/schemas/TrackingUrl.json
@@ -1,0 +1,6 @@
+{
+  "readOnly": true,
+  "type": "string",
+  "example": "https://tracker.carrier.com/3SABCD0123456789",
+  "description": "URL used to view tracking status updates."
+}


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-4170
- Fixed bug where `colli` relationship contained entire shipment resources instead of `id` + `type`.
- Added `meta` with base64 filedata to `colli` relationship of `/register-multi-colli-shipment` response.
- Fixed authentication token URL.