### PR TITLE
MP-4331 Service option meta

### DIFF
--- a/specification/schemas/ServiceOption.json
+++ b/specification/schemas/ServiceOption.json
@@ -35,8 +35,16 @@
             "code": {
               "type": "string",
               "example": "delivery-window:sunday"
-            },
-            "meta_format": {
+            }
+          }
+        },
+        "meta": {
+          "type": "object",
+          "required": [
+            "values_format"
+          ],
+          "properties": {
+            "values_format": {
               "type": "object",
               "example": {
                 "required": [
@@ -53,7 +61,7 @@
                   }
                 }
               },
-              "description": "JSON Schema specification of optional meta information for this service option. This meta information should be specified in the meta of the `service_options` relationship when posting a shipment."
+              "description": "JSON Schema specification of the optional `values` property in the meta of this service option, when posted as a relationship of a shipment. See `data.relationships.service_options.data.*.meta` in POST `/shipments` request body."
             }
           }
         },

--- a/specification/schemas/ServiceOption.json
+++ b/specification/schemas/ServiceOption.json
@@ -36,7 +36,7 @@
               "type": "string",
               "example": "delivery-window:sunday"
             },
-            "meta-format": {
+            "meta_format": {
               "type": "object",
               "example": {
                 "required": [

--- a/specification/schemas/ServiceOption.json
+++ b/specification/schemas/ServiceOption.json
@@ -53,7 +53,7 @@
                   }
                 }
               },
-              "description": "JSON Schema specification of optional meta information for this service option. This meta information should be specified in the meta of the relationship when posting a shipment."
+              "description": "JSON Schema specification of optional meta information for this service option. This meta information should be specified in the meta of the `service_options` relationship when posting a shipment."
             }
           }
         },

--- a/specification/schemas/ServiceOption.json
+++ b/specification/schemas/ServiceOption.json
@@ -35,6 +35,25 @@
             "code": {
               "type": "string",
               "example": "delivery-window:sunday"
+            },
+            "meta-format": {
+              "type": "object",
+              "example": {
+                "required": [
+                  "amount",
+                  "currency"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "amount": {
+                    "type": "integer"
+                  },
+                  "currency": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "JSON Schema specification of optional meta information for this service option. This meta information should be specified in the meta of the relationship when posting a shipment."
             }
           }
         },

--- a/specification/schemas/ServiceOptionsRelationship.json
+++ b/specification/schemas/ServiceOptionsRelationship.json
@@ -22,7 +22,7 @@
                   "object",
                   "null"
                 ],
-                "description": "Optional meta information specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash on delivery options. See the service option's `meta-format` property for specific requirements per service option."
+                "description": "Optional meta information specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash on delivery options. See the service option's `meta_format` property for specific requirements per service option."
               }
             }
           }

--- a/specification/schemas/ServiceOptionsRelationship.json
+++ b/specification/schemas/ServiceOptionsRelationship.json
@@ -15,7 +15,16 @@
           {
             "required": [
               "id"
-            ]
+            ],
+            "properties": {
+              "meta": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Optional meta information specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash on delivery options. See the service option's `meta-format` property for specific requirements per service option."
+              }
+            }
           }
         ]
       }

--- a/specification/schemas/ServiceOptionsRelationship.json
+++ b/specification/schemas/ServiceOptionsRelationship.json
@@ -15,16 +15,7 @@
           {
             "required": [
               "id"
-            ],
-            "properties": {
-              "meta": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "description": "Optional meta information specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash on delivery options. See the service option's `meta_format` property for specific requirements per service option."
-              }
-            }
+            ]
           }
         ]
       }

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -298,7 +298,36 @@
             "service_options": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/ServiceOptionsRelationship"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ServiceOptionsRelationship"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "items": {
+                            "required": [
+                              "id",
+                              "type"
+                            ],
+                            "properties": {
+                              "meta": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "description": "Optional meta information specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash-on-delivery options. See the service option's `meta_format` property for specific requirements per service option.",
+                                "example": {
+                                  "amount": "1200",
+                                  "currency": "EUR"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
                 },
                 {
                   "type": "null"

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -312,14 +312,19 @@
                             ],
                             "properties": {
                               "meta": {
-                                "type": [
-                                  "object",
-                                  "null"
+                                "type": "object",
+                                "required": [
+                                  "values"
                                 ],
-                                "description": "Optional meta information specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash-on-delivery options. See the service option's `meta_format` property for specific requirements per service option.",
-                                "example": {
-                                  "amount": "1200",
-                                  "currency": "EUR"
+                                "properties": {
+                                  "values": {
+                                    "type": "object",
+                                    "description": "Optional meta values specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash-on-delivery options. See the service option's `values_format` meta property for specific requirements per service option.",
+                                    "example": {
+                                      "amount": "1200",
+                                      "currency": "EUR"
+                                    }
+                                  }
                                 }
                               }
                             }


### PR DESCRIPTION
## Changes
- Added `values_format` meta property on ServiceOption schema.
- Added optional `meta.values` on `service_options` relationship in Shipment schema to allow users to pass on information specifically for a single service option.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-4305 [Story]
- https://myparcelcombv.atlassian.net/browse/MP-4331 [Subtask]