### PR TITLE
MP-4339 Tax Identification Number attributes on Shipment schema

### DIFF
--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -12,12 +12,19 @@
             "recipient_address": {
               "$ref": "#/components/schemas/BaseAddress"
             },
+            "recipient_tax_identification_numbers": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/TaxIdentificationNumber"
+              }
+            },
             "recipient_tax_number": {
               "type": [
                 "string",
                 "null"
               ],
-              "example": "H111111-11"
+              "example": "H111111-11",
+              "deprecated": true
             },
             "return_address": {
               "$ref": "#/components/schemas/BaseAddress"
@@ -25,12 +32,20 @@
             "sender_address": {
               "$ref": "#/components/schemas/BaseAddress"
             },
+            "sender_tax_identification_numbers": {
+              "type": "array",
+              "description": "Sender tax numbers provided with a shipment will overwrite any tax identification numbers of the same `type` and `country_code` that are defined on the parent Organization resource of the Shop related to the Shipment.",
+              "items": {
+                "$ref": "#/components/schemas/TaxIdentificationNumber"
+              }
+            },
             "sender_tax_number": {
               "type": [
                 "string",
                 "null"
               ],
-              "example": "G666666-66"
+              "example": "G666666-66",
+              "deprecated": true
             },
             "pickup_location": {
               "oneOf": [

--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -23,7 +23,7 @@
                 "string",
                 "null"
               ],
-              "example": "H111111-11",
+              "description": "Use `recipient_tax_identification_numbers` instead.",
               "deprecated": true
             },
             "return_address": {
@@ -34,7 +34,7 @@
             },
             "sender_tax_identification_numbers": {
               "type": "array",
-              "description": "Sender tax numbers provided with a shipment will overwrite any tax identification numbers of the same `type` and `country_code` that are defined on the parent Organization resource of the Shop related to the Shipment.",
+              "description": "Sender tax numbers provided with a shipment will overwrite any tax identification numbers of the same `type` and `country_code` defined on the organization of the shop related to this shipment.",
               "items": {
                 "$ref": "#/components/schemas/TaxIdentificationNumber"
               }
@@ -44,7 +44,7 @@
                 "string",
                 "null"
               ],
-              "example": "G666666-66",
+              "description": "Use `sender_tax_identification_numbers` instead.",
               "deprecated": true
             },
             "pickup_location": {


### PR DESCRIPTION
## Changes
- Introduced `recipient_tax_identification_numbers` and `sender_tax_identification_numbers` attributes on the Shipment schema.
- Marked `recipient_tax_number` and `sender_tax_number` attributes on the Shipment schema as **deprecated**.

## Related Issues
- [Subtask] https://myparcelcombv.atlassian.net/browse/MP-4339
- [Story] https://myparcelcombv.atlassian.net/browse/MP-4334