### PR TITLE
♿️ Sync tax-identification-number schema with carrier-specification

### DIFF
--- a/specification/paths/RegisteredShipments.json
+++ b/specification/paths/RegisteredShipments.json
@@ -27,7 +27,7 @@
               "data": {
                 "$ref": "#/components/schemas/Shipment"
               },
-              "meta":  {
+              "meta": {
                 "type": "object",
                 "properties": {
                   "label_mime_type": {

--- a/specification/paths/UpdateShipmentStatus.json
+++ b/specification/paths/UpdateShipmentStatus.json
@@ -41,7 +41,7 @@
                     "pattern": "^[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$",
                     "example": "5c868557-0827-4d21-a7f4-9820f01769f4"
                   },
-                  "carrier_statuses":  {
+                  "carrier_statuses": {
                     "type": "array",
                     "items": {
                       "$ref": "#/components/schemas/CarrierStatus"

--- a/specification/schemas/TaxIdentificationNumber.json
+++ b/specification/schemas/TaxIdentificationNumber.json
@@ -12,12 +12,14 @@
     },
     "number": {
       "type": "string",
-      "example": "XI123456789",
-      "description": "Eori XI number"
+      "example": "XI123456789"
     },
     "description": {
-      "type": ["string", "null"],
-      "example": "Eori XI number for Northern Ireland"
+      "type": [
+        "string",
+        "null"
+      ],
+      "example": "Eori number for Northern Ireland"
     },
     "type": {
       "type": "string",


### PR DESCRIPTION
The description on the tax `number` attribute was too specific.