### PR TITLE
Incorrect type of service option value example

### DIFF
--- a/specification/schemas/Shipment.json
+++ b/specification/schemas/Shipment.json
@@ -336,7 +336,7 @@
                                     "type": "object",
                                     "description": "Optional meta values specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash-on-delivery options. See the service option's `values_format` meta property for specific requirements per service option.",
                                     "example": {
-                                      "amount": "1200",
+                                      "amount": 1200,
                                       "currency": "EUR"
                                     }
                                   }


### PR DESCRIPTION
## Changes
- Fix incorrect type of `amount` example on service option relationship in Shipment schema.