### PR TITLE
🛎️ MP-3746 removed pagination for broker carriers relationships

### DIFF
--- a/specification/paths/Brokers-broker_id-carriers.json
+++ b/specification/paths/Brokers-broker_id-carriers.json
@@ -40,17 +40,7 @@
                         "required": [
                           "id",
                           "links"
-                        ],
-                        "properties": {
-                          "attributes": {
-                            "required": [
-                              "status",
-                              "currency",
-                              "name",
-                              "created_at"
-                            ]
-                          }
-                        }
+                        ]
                       }
                     ]
                   }
@@ -61,30 +51,13 @@
                 "links": {
                   "type": "object",
                   "required": [
-                    "self",
-                    "first",
-                    "last"
+                    "self"
                   ],
                   "properties": {
                     "self": {
                       "type": "string",
-                      "example": "$API_HOST/brokers/a294ee55-bc94-4890-b734-afd56c158f95/carriers?page[number]=3&page[size]=30"
-                    },
-                    "first": {
-                      "type": "string",
-                      "example": "$API_HOST/brokers/a294ee55-bc94-4890-b734-afd56c158f95/carriers?page[number]=1&page[size]=30"
-                    },
-                    "prev": {
-                      "type": "string",
-                      "example": "$API_HOST/brokers/a294ee55-bc94-4890-b734-afd56c158f95/carriers?page[number]=2&page[size]=30"
-                    },
-                    "next": {
-                      "type": "string",
-                      "example": "$API_HOST/brokers/a294ee55-bc94-4890-b734-afd56c158f95/carriers?page[number]=4&page[size]=30"
-                    },
-                    "last": {
-                      "type": "string",
-                      "example": "$API_HOST/brokers/a294ee55-bc94-4890-b734-afd56c158f95/carriers?page[number]=13&page[size]=30"
+                      "format": "url",
+                      "example": "$API_HOST/brokers/a294ee55-bc94-4890-b734-afd56c158f95/carriers"
                     }
                   }
                 }


### PR DESCRIPTION
## Changes
- We only retrieve carriers for 1 broker and therefore the broker itself doesn't have pagination links. 