### PR TITLE
♻️ Update patch shipment model to be in line with other shipment models

### DIFF
--- a/specification/paths/Shipments-shipment_id.json
+++ b/specification/paths/Shipments-shipment_id.json
@@ -90,7 +90,26 @@
                 "properties": {
                   "label_mime_type": {
                     "type": "string",
-                    "example": "application/pdf"
+                    "example": "application/pdf",
+                    "deprecated": true,
+                    "description": "Deprecated, use `label.mime_type` instead. In case both are used, `label.mime_type` will get priority."
+                  },
+                  "label": {
+                    "type": "object",
+                    "properties": {
+                      "mime_type": {
+                        "type": "string",
+                        "example": "application/pdf",
+                        "default": "application/pdf",
+                        "description": "Requested `mime_type` for the label of this shipment. Available mime_types can be found on the carrier resource related to the chosen service/contract."
+                      },
+                      "size": {
+                        "type": "string",
+                        "example": "A6",
+                        "default": "A6",
+                        "description": "Requested size for the label of this shipment. Available label sizes can be found on the carrier resource related to the chosen service/contract."
+                      }
+                    }
                   },
                   "service_code": {
                     "type": "string",


### PR DESCRIPTION
When introducing the `label.mime_type` we forgot to update the Shipment model used in the patch request.