### PR TITLE
Invoice number should be nullable

### DIFF
--- a/specification/schemas/BaseCustoms.json
+++ b/specification/schemas/BaseCustoms.json
@@ -14,7 +14,11 @@
       "example": "sample_merchandise"
     },
     "invoice_number": {
-      "type": "string",
+      "type": [
+        "null",
+        "string"
+      ],
+      "description": "Required when `content_type` is either `merchandise`, `sample_merchandise` or `returned_merchandise`.",
       "example": "9000"
     },
     "non_delivery": {


### PR DESCRIPTION
## Changes
- Added `null` as a possible type for `shipment.attributes.customs.invoice_number` property.
- Added a description to `shipment.attributes.customs.invoice_number` property to indicate when it is required.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-4368