### PR TITLE
All shipment customs properties should be nullable

### DIFF
--- a/specification/schemas/BaseCustoms.json
+++ b/specification/schemas/BaseCustoms.json
@@ -16,7 +16,7 @@
           "example": "sample_merchandise"
         },
         {
-          "type": null
+          "type": "null"
         }
       ]
     },
@@ -40,7 +40,7 @@
           "description": "Action when the parcel cannot be delivered."
         },
         {
-          "type": null
+          "type": "null"
         }
       ]
     },
@@ -56,7 +56,7 @@
           "description": "DAP (Delivered At Place) or DDP (Delivered Duty Paid)."
         },
         {
-          "type": null
+          "type": "null"
         }
       ]
     },


### PR DESCRIPTION
## Changes
- Added a oneOf argument to all customs properties to allow `null` values where enums are expected.