### PR TITLE
MP-4189 Changed manifest schema file relationship to one to Many.

### DIFF
--- a/specification/schemas/Manifest.json
+++ b/specification/schemas/Manifest.json
@@ -26,10 +26,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "file": {
+            "files": {
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/FileRelationship"
+                  "$ref": "#/components/schemas/FilesRelationship"
                 },
                 {
                   "readOnly": true


### PR DESCRIPTION
## Changes
- Because we are now going to generate both types of manifest, itemized and summarized, we need to change the file relationship of the manifest into one to many. 

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-4189