### PR TITLE
♻️ Allow broker members to get enterprises

### DIFF
--- a/specification/paths/Brokers-broker_id-carriers.json
+++ b/specification/paths/Brokers-broker_id-carriers.json
@@ -11,6 +11,7 @@
     "security": [
       {
         "OAuth2": [
+          "broker.member",
           "enterprise.manage"
         ]
       }

--- a/specification/paths/Brokers-broker_id-relationships-carriers.json
+++ b/specification/paths/Brokers-broker_id-relationships-carriers.json
@@ -11,6 +11,7 @@
     "security": [
       {
         "OAuth2": [
+          "broker.member",
           "enterprise.manage"
         ]
       }

--- a/specification/paths/Brokers-broker_id-relationships-carriers.json
+++ b/specification/paths/Brokers-broker_id-relationships-carriers.json
@@ -11,7 +11,6 @@
     "security": [
       {
         "OAuth2": [
-          "broker.member",
           "enterprise.manage"
         ]
       }

--- a/specification/paths/Enterprises-enterprise_id.json
+++ b/specification/paths/Enterprises-enterprise_id.json
@@ -11,6 +11,7 @@
     "security": [
       {
         "OAuth2": [
+          "broker.member",
           "enterprises.manage"
         ]
       }

--- a/specification/paths/Enterprises.json
+++ b/specification/paths/Enterprises.json
@@ -6,6 +6,7 @@
     "security": [
       {
         "OAuth2": [
+          "broker.member",
           "enterprises.manage"
         ]
       }


### PR DESCRIPTION
Brokers have an Enterprise relationship, so the links in there should be retrievable with the same token. Since the broker endpoints have `broker.member` and `enterprises.manage` scopes, the enterprise endpoints should have this as well.