### PR TITLE
MP-4649 🧐 in operator for hooks

### DIFF
--- a/specification/schemas/HookTrigger.json
+++ b/specification/schemas/HookTrigger.json
@@ -39,7 +39,8 @@
               "<",
               ">=",
               "<=",
-              "contains"
+              "contains",
+              "in"
             ],
             "example": "=="
           },
@@ -50,7 +51,8 @@
           "value": {
             "type": [
               "string",
-              "number"
+              "number",
+              "array"
             ],
             "example": 1000
           }


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-4441
- Update hook predicates
  - Added `in` as possible operator
  - Added `array` as possible value type