### PR TITLE
MP-4657 ✨ Dynamic service-rates endpoint

### DIFF
--- a/specification/paths.json
+++ b/specification/paths.json
@@ -68,6 +68,9 @@
   "/files/{file_id}": {
     "$ref": "./paths/Files-file_id.json"
   },
+  "/get-dynamic-service-rates": {
+    "$ref": "./paths/GetDynamicServiceRates.json"
+  },
   "/hooks": {
     "$ref": "./paths/Hooks.json"
   },

--- a/specification/paths/GetDynamicServiceRates.json
+++ b/specification/paths/GetDynamicServiceRates.json
@@ -1,0 +1,142 @@
+{
+  "post": {
+    "tags": [
+      "RPC"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "organizations.manage"
+        ]
+      }
+    ],
+    "summary": "Get dynamic service rates.",
+    "description": "This endpoint retrieves service rates from the carrier using the specified shipment. A service and contract are required to know which carrier to communicate with.",
+    "requestBody": {
+      "description": "The shipment object with a service and contract.",
+      "required": true,
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Shipment"
+                  },
+                  {
+                    "required": [
+                      "attributes",
+                      "relationships"
+                    ],
+                    "properties": {
+                      "id": {
+                        "readOnly": true
+                      },
+                      "attributes": {
+                        "required": [
+                          "recipient_address",
+                          "sender_address",
+                          "physical_properties"
+                        ],
+                        "properties": {
+                          "recipient_address": {
+                            "required": [
+                              "street_1",
+                              "city",
+                              "country_code"
+                            ]
+                          },
+                          "sender_address": {
+                            "required": [
+                              "street_1",
+                              "city",
+                              "country_code"
+                            ]
+                          },
+                          "physical_properties": {
+                            "required": [
+                              "weight"
+                            ]
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "required": [
+                          "contract",
+                          "service"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "Retrieved the service rates.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data",
+                "meta",
+                "links"
+              ],
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/ServiceRate"
+                      },
+                      {
+                        "properties": {
+                          "relationships": {
+                            "properties": {
+                              "service_options": {
+                                "properties": {
+                                  "data": {
+                                    "items": {
+                                      "required": [
+                                        "id",
+                                        "type",
+                                        "meta"
+                                      ],
+                                      "properties": {
+                                        "meta": {
+                                          "required": [
+                                            "included"
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/paths/GetDynamicServiceRates.json
+++ b/specification/paths/GetDynamicServiceRates.json
@@ -6,7 +6,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/paths/ServiceRates-service_rate_id.json
+++ b/specification/paths/ServiceRates-service_rate_id.json
@@ -11,7 +11,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -6,7 +6,8 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage"
+          "organizations.manage",
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/schemas/ServiceRate.json
+++ b/specification/schemas/ServiceRate.json
@@ -47,6 +47,11 @@
               "example": 12.5,
               "description": "Volume in liters. (dm3)"
             },
+            "is_dynamic": {
+              "type": "boolean",
+              "default": false,
+              "description": "When a service rate is dynamic, it's price depends on complicated carrier logic. You can use the <a href='#tag/RPC/paths/~1get-dynamic-service-rates/post'>/get-dynamic-service-rates</a> RPC endpoint to retrieve the current rates from the carrier."
+            },
             "price": {
               "$ref": "#/components/schemas/Price"
             },


### PR DESCRIPTION
Subtask of https://myparcelcombv.atlassian.net/browse/MP-4367
- Added `is_dynamic` boolean to ServiceRate resource.
- Added `POST /get-dynamic-service-rates` endpoint.
- Allowed `shipments.manage` to retrieve ServiceRate resources (this is already possible in the API).