### PR TITLE
✨ Contract and carrier include on manifests

### DIFF
--- a/specification/paths/Manifests-manifest_id.json
+++ b/specification/paths/Manifests-manifest_id.json
@@ -22,7 +22,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Manifests.json
+++ b/specification/paths/Manifests.json
@@ -17,7 +17,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li></ul>",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
## Changes
- Introduced `contract` and `contract.carrier` include on manifests endpoints.
