### PR TITLE
♻️ Allow integers as date filters

### DIFF
--- a/specification/parameters/query-filter-created_at-date_from.json
+++ b/specification/parameters/query-filter-created_at-date_from.json
@@ -1,8 +1,11 @@
 {
   "name": "filter[created_at][date_from]",
   "in": "query",
-  "description": "Date string in ISO 8601 date format (YYYY-MM-DD) or unix timestamp. Only resources created at >= this date will be in the response.",
+  "description": "Date string in ISO 8601 format or unix timestamp. Only resources created at >= this date will be in the response.",
   "schema": {
-    "type": "string"
+    "type": [
+      "string",
+      "number"
+    ]
   }
 }

--- a/specification/parameters/query-filter-created_at-date_to.json
+++ b/specification/parameters/query-filter-created_at-date_to.json
@@ -1,8 +1,11 @@
 {
   "name": "filter[created_at][date_to]",
   "in": "query",
-  "description": "Date string in ISO 8601 date format (YYYY-MM-DD) or unix timestamp. Only resources created at <= this date will be in the response.",
+  "description": "Date string in ISO 8601 format or unix timestamp. Only resources created at <= this date will be in the response.",
   "schema": {
-    "type": "string"
+    "type": [
+      "string",
+      "number"
+    ]
   }
 }

--- a/specification/parameters/query-shipments-filter-register_at-date_from.json
+++ b/specification/parameters/query-shipments-filter-register_at-date_from.json
@@ -1,8 +1,11 @@
 {
   "name": "filter[register_at][date_from]",
   "in": "query",
-  "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments registered at >= this date will be in the response.",
+  "description": "Date string in ISO 8601 format or unix timestamp. Only shipments registered at >= this date will be in the response.",
   "schema": {
-    "type": "string"
+    "type": [
+      "string",
+      "number"
+    ]
   }
 }

--- a/specification/parameters/query-shipments-filter-register_at-date_to.json
+++ b/specification/parameters/query-shipments-filter-register_at-date_to.json
@@ -1,8 +1,11 @@
 {
   "name": "filter[register_at][date_to]",
   "in": "query",
-  "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments registered at <= this date will be in the response.",
+  "description": "Date string in ISO 8601 format or unix timestamp. Only shipments registered at <= this date will be in the response.",
   "schema": {
-    "type": "string"
+    "type": [
+      "string",
+      "number"
+    ]
   }
 }

--- a/specification/schemas/Report.json
+++ b/specification/schemas/Report.json
@@ -25,13 +25,19 @@
                   ],
                   "properties": {
                     "date_from": {
-                      "type": "string",
-                      "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments created at >= this date will be in the report.",
+                      "type": [
+                        "string",
+                        "number"
+                      ],
+                      "description": "Date string in ISO 8601 format or unix timestamp. Only shipments created at >= this date will be in the report.",
                       "example": "2020-01-01"
                     },
                     "date_to": {
-                      "type": "string",
-                      "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments created at <= this date will be in the response.",
+                      "type": [
+                        "string",
+                        "number"
+                      ],
+                      "description": "Date string in ISO 8601 format or unix timestamp. Only shipments created at <= this date will be in the response.",
                       "example": "2020-03-31"
                     }
                   }
@@ -45,13 +51,19 @@
                   ],
                   "properties": {
                     "date_from": {
-                      "type": "string",
-                      "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments registered at >= this date will be in the report.",
+                      "type": [
+                        "string",
+                        "number"
+                      ],
+                      "description": "Date string in ISO 8601 format or unix timestamp. Only shipments registered at >= this date will be in the report.",
                       "example": "2020-01-01"
                     },
                     "date_to": {
-                      "type": "string",
-                      "description": "Date string in ISO 8601 date format (YYYY-MM-DD). Only shipments registered at <= this date will be in the response.",
+                      "type": [
+                        "string",
+                        "number"
+                      ],
+                      "description": "Date string in ISO 8601 format or unix timestamp. Only shipments registered at <= this date will be in the response.",
                       "example": "2020-03-31"
                     }
                   }


### PR DESCRIPTION
When sending timestamps as date filters, the type is an integer (in the `POST /reports` body).