### PR TITLE
Removed required fields 

### DIFF
--- a/specification/paths/Zones.json
+++ b/specification/paths/Zones.json
@@ -125,8 +125,7 @@
                         "required": [
                           "country_codes",
                           "code",
-                          "name",
-                          "description"
+                          "name"
                         ]
                       }
                     }

--- a/specification/schemas/Zone.json
+++ b/specification/schemas/Zone.json
@@ -7,11 +7,6 @@
       "properties": {
         "attributes": {
           "type": "object",
-          "required": [
-            "country_codes",
-            "code",
-            "name"
-          ],
           "additionalProperties": false,
           "properties": {
             "postal_code": {


### PR DESCRIPTION
Upon building the patch endpoint for the Zone resource I noticed that we made specific fields always required. This shouldnt be the case when patching a zone.