### PR TITLE
Put zones with other resources in the list

### DIFF
--- a/specification/tags.json
+++ b/specification/tags.json
@@ -175,6 +175,11 @@
     }
   },
   {
+    "name": "Zones",
+    "externalDocs": {
+    }
+  },
+  {
     "name": "RPC",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/rpc-endpoints",
@@ -183,11 +188,6 @@
   },
   {
     "name": "Analytics",
-    "externalDocs": {
-    }
-  },
-  {
-    "name": "Zones",
     "externalDocs": {
     }
   }


### PR DESCRIPTION
Zones are a resource and as such, they should be listed with the other endpoints, above RPC and analytics endpoints.