### PR TITLE
🔥 Remove status attribute from zone resource

### DIFF
--- a/specification/paths/Zones-zone_id.json
+++ b/specification/paths/Zones-zone_id.json
@@ -72,17 +72,7 @@
                   {
                     "required": [
                       "id"
-                    ],
-                    "properties": {
-                      "attributes": {
-                        "properties": {
-                          "status": {
-                            "example": "blocked",
-                            "description": "Can only be updated when your access token contains the `zones.manage` scope on the broker."
-                          }
-                        }
-                      }
-                    }
+                    ]
                   }
                 ]
               }

--- a/specification/paths/Zones.json
+++ b/specification/paths/Zones.json
@@ -16,7 +16,7 @@
       {
         "name": "filter[search]",
         "in": "query",
-        "description": "String of characters you want to look for in a zone's attributes. Available fields to look in are:<ul><li>`name`</li><li>`description`</li><li>`code`</li></ul>",
+        "description": "String of characters you want to look for in a zone's attributes. Available fields to look in are:<ul><li>`name`</li><li>`code`</li><li>`description`</li></ul>",
         "schema": {
           "type": "string"
         }
@@ -123,9 +123,9 @@
                       },
                       "attributes": {
                         "required": [
-                          "country_codes",
+                          "name",
                           "code",
-                          "name"
+                          "country_codes"
                         ]
                       }
                     }

--- a/specification/schemas/Zone.json
+++ b/specification/schemas/Zone.json
@@ -9,6 +9,24 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "name": {
+              "type": "string",
+              "example": "EU territory 1A",
+              "description": "The name of the resource."
+            },
+            "code": {
+              "type": "string",
+              "example": "1A",
+              "description": "The code used by the system to identify the resource."
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "Countries in Europe that aren't part of the European Union",
+              "description": "A description of the resource."
+            },
             "postal_code": {
               "type": [
                 "string",
@@ -16,12 +34,6 @@
               ],
               "example": "^((GY|JE).*|TR2[1-5]) ?[0-9]{1}[A-Z]{2}$",
               "description": "Regular expression matching postal code areas."
-            },
-            "country_codes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CountryCode"
-              }
             },
             "state_codes": {
               "type": "array",
@@ -36,23 +48,11 @@
                 ]
               }
             },
-            "code": {
-              "type": "string",
-              "example": "EU_TERRITORY_1A",
-              "description": "The code used by the system to identify the resource."
-            },
-            "name": {
-              "type": "string",
-              "example": "EU territory 1A",
-              "description": "The name of the resource."
-            },
-            "description": {
-              "type": [
-                "string",
-                "null"
-              ],
-              "example": "Countries in Europe that aren't part of the European Union",
-              "description": "A description of the resource."
+            "country_codes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CountryCode"
+              }
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"

--- a/specification/schemas/ZoneResponse.json
+++ b/specification/schemas/ZoneResponse.json
@@ -11,9 +11,9 @@
       "properties": {
         "attributes": {
           "required": [
-            "country_codes",
-            "code",
             "name",
+            "code",
+            "country_codes",
             "created_at"
           ]
         },


### PR DESCRIPTION
- Remove status attribute from zone resource.
- Order zone attributes to be in line with other resources.