### PR TITLE
🐛 Restucture address setup to allow patch without attributes

### DIFF
--- a/specification/paths/Addresses-address_id.json
+++ b/specification/paths/Addresses-address_id.json
@@ -28,19 +28,10 @@
               "required": [
                 "data"
               ],
+              "additionalProperties": false,
               "properties": {
                 "data": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/Address"
-                    },
-                    {
-                      "required": [
-                        "id",
-                        "links"
-                      ]
-                    }
-                  ]
+                  "$ref": "#/components/schemas/AddressResponse"
                 }
               }
             }
@@ -77,16 +68,15 @@
               "data": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/AddressResource"
+                    "$ref": "#/components/schemas/Address"
                   },
                   {
                     "required": [
-                      "id",
-                      "attributes"
+                      "id"
                     ],
                     "properties": {
-                      "attributes": {
-                        "$ref": "#/components/schemas/BaseAddress"
+                      "relationships": {
+                        "readOnly": true
                       }
                     }
                   }
@@ -110,17 +100,7 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/Address"
-                    },
-                    {
-                      "required": [
-                        "id",
-                        "links"
-                      ]
-                    }
-                  ]
+                  "$ref": "#/components/schemas/AddressResponse"
                 }
               }
             }

--- a/specification/paths/Addresses.json
+++ b/specification/paths/Addresses.json
@@ -43,17 +43,7 @@
                 "data": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/Address"
-                      },
-                      {
-                        "required": [
-                          "id",
-                          "links"
-                        ]
-                      }
-                    ]
+                    "$ref": "#/components/schemas/AddressResponse"
                   }
                 },
                 "meta": {
@@ -128,9 +118,20 @@
                     "$ref": "#/components/schemas/Address"
                   },
                   {
+                    "required": [
+                      "attributes",
+                      "relationships"
+                    ],
                     "properties": {
                       "id": {
                         "readOnly": true
+                      },
+                      "attributes": {
+                        "required": [
+                          "street_1",
+                          "city",
+                          "country_code"
+                        ]
                       }
                     }
                   }
@@ -154,17 +155,7 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/Address"
-                    },
-                    {
-                      "required": [
-                        "id",
-                        "links"
-                      ]
-                    }
-                  ]
+                  "$ref": "#/components/schemas/AddressResponse"
                 }
               }
             }

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -5,6 +5,9 @@
   "AddressResource": {
     "$ref": "./schemas/AddressResource.json"
   },
+  "AddressResponse": {
+    "$ref": "./schemas/AddressResponse.json"
+  },
   "Barcode": {
     "$ref": "./schemas/Barcode.json"
   },

--- a/specification/schemas/Address.json
+++ b/specification/schemas/Address.json
@@ -4,24 +4,9 @@
       "$ref": "#/components/schemas/AddressResource"
     },
     {
-      "required": [
-        "attributes",
-        "relationships"
-      ],
       "properties": {
         "attributes": {
-          "allOf": [
-            {
-              "required": [
-                "street_1",
-                "city",
-                "country_code"
-              ]
-            },
-            {
-              "$ref": "#/components/schemas/BaseAddress"
-            }
-          ]
+          "$ref": "#/components/schemas/BaseAddress"
         },
         "relationships": {
           "type": "object",
@@ -31,21 +16,6 @@
           "properties": {
             "organization": {
               "$ref": "#/components/schemas/OrganizationRelationship"
-            }
-          }
-        },
-        "links": {
-          "readOnly": true,
-          "type": "object",
-          "required": [
-            "self"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "self": {
-              "type": "string",
-              "format": "url",
-              "example": "$API_HOST/addresses/1154bfbc-322b-48d9-8f78-be0b467f258d"
             }
           }
         }

--- a/specification/schemas/AddressResponse.json
+++ b/specification/schemas/AddressResponse.json
@@ -1,22 +1,21 @@
 {
   "allOf": [
     {
-      "$ref": "#/components/schemas/Status"
+      "$ref": "#/components/schemas/Address"
     },
     {
       "required": [
         "id",
         "attributes",
+        "relationships",
         "links"
       ],
       "properties": {
         "attributes": {
           "required": [
-            "code",
-            "resource_type",
-            "name",
-            "description",
-            "level"
+            "street_1",
+            "city",
+            "country_code"
           ]
         },
         "links": {
@@ -30,7 +29,7 @@
             "self": {
               "type": "string",
               "format": "url",
-              "example": "$API_HOST/statuses/5c868557-0827-4d21-a7f4-9820f01769f4"
+              "example": "$API_HOST/addresses/1154bfbc-322b-48d9-8f78-be0b467f258d"
             }
           }
         }

--- a/specification/schemas/BrokerResponse.json
+++ b/specification/schemas/BrokerResponse.json
@@ -7,7 +7,8 @@
       "required": [
         "id",
         "attributes",
-        "relationships"
+        "relationships",
+        "links"
       ],
       "properties": {
         "attributes": {

--- a/specification/schemas/EnterpriseResponse.json
+++ b/specification/schemas/EnterpriseResponse.json
@@ -6,7 +6,8 @@
     {
       "required": [
         "id",
-        "attributes"
+        "attributes",
+        "links"
       ],
       "properties": {
         "attributes": {

--- a/specification/schemas/SystemMessageResponse.json
+++ b/specification/schemas/SystemMessageResponse.json
@@ -7,7 +7,8 @@
       "required": [
         "id",
         "attributes",
-        "relationships"
+        "relationships",
+        "links"
       ],
       "properties": {
         "attributes": {

--- a/specification/schemas/ZoneResponse.json
+++ b/specification/schemas/ZoneResponse.json
@@ -6,7 +6,8 @@
     {
       "required": [
         "id",
-        "attributes"
+        "attributes",
+        "links"
       ],
       "properties": {
         "attributes": {


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-4775
---
The `attributes` were required when patching an address, but this is not sent by our app when there are no changes.

I also introduced an `AddressResponse` (to avoid code duplication) and marked some `links` in responses as required because we always output them.