### PR TITLE
✨  Import resource action on hooks

### DIFF
--- a/specification/paths/Hooks.json
+++ b/specification/paths/Hooks.json
@@ -30,6 +30,19 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "filter[trigger][resource_action]",
+        "in": "query",
+        "description": "[Resource action](https://docs.myparcel.com/api/resources/hooks/trigger/) to filter the hooks by.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "create",
+            "update",
+            "import"
+          ]
+        }
       }
     ],
     "responses": {

--- a/specification/paths/Hooks.json
+++ b/specification/paths/Hooks.json
@@ -24,7 +24,7 @@
         }
       },
       {
-        "name": "filter[action_type]",
+        "name": "filter[action][action_type]",
         "in": "query",
         "description": "[Action type](https://docs.myparcel.com/api/resources/hooks/action/) to filter the hooks by.",
         "schema": {

--- a/specification/schemas/HookTrigger.json
+++ b/specification/schemas/HookTrigger.json
@@ -15,7 +15,7 @@
       "enum": [
         "create",
         "update",
-        "delete"
+        "import"
       ]
     },
     "predicates": {


### PR DESCRIPTION
## Changes
- Added `import` as possible `resource_action` on hooks.
- Removed `delete` as possible `resource_action` on hooks since it's not used and our docs also doesn't mention it.
- Added filter[trigger][resource_action] filter to the hooks endpoint. We already have filter[action_type]. Should we rename that to filter[action][action_type] :question: 

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-4812 - Subtask
- https://myparcelcombv.atlassian.net/browse/MP-4575 - Story