### PR TITLE
MP-4674 Dynamic volumetric weight calculation

### DIFF
--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -41,7 +41,16 @@
       {
         "name": "filter[volumetric_weight]",
         "in": "query",
-        "description": "Volumetric weight value in grams to filter by. <br>Service rates for services that use volumetric weight will be filtered on the highest value between gross weight and volumetric weight. Use in conjunction with the filter[weight] filter above.",
+        "description": "<strike>Volumetric weight value in grams to filter by. <br>Service rates for services that use volumetric weight will be filtered on the highest value between gross weight and volumetric weight. Use in conjunction with the filter[weight] filter above.</strike> Deprecated in favor of `filter[volume]`",
+        "schema": {
+          "type": "string"
+        },
+        "deprecated": true
+      },
+      {
+        "name": "filter[volume]",
+        "in": "query",
+        "description": "This filter expects shipment volume in liters (dm3). This is used to calculate the volumetric weight, using the `volumetric_weight_divisor` of each service rate. Service rates are then filtered based on their weight range. It is recommended to use this filter in conjunction with the `filter[weight]` filter to get the most accurate results.",
         "schema": {
           "type": "string"
         }

--- a/specification/schemas/ServiceRate.json
+++ b/specification/schemas/ServiceRate.json
@@ -47,6 +47,12 @@
               "example": 12.5,
               "description": "Volume in liters. (dm3)"
             },
+            "volumetric_weight_divisor": {
+              "type": "number",
+              "example": 5000,
+              "description": "The volumetric weight divisor is used to calculate the volumetric weight of a shipment. Multiplying the length (mm) x width (mm) x height (mm) of a shipment and dividing it by this number will result in the volumetric weight (g). See <a href=\"https://docs.myparcel.com/api/resources/shipments/physical-properties/volumetric-weight\"/>the documentation</a> for more information.",
+              "default": 5000
+            },
             "is_dynamic": {
               "type": "boolean",
               "default": false,


### PR DESCRIPTION
## Changes
- Introduced `volumetric_weight_divisor` property on ServiceRate schema.
- Deprecated `filter[volumetric_weight]` filter on GET /service-rates endpoint.
- Introduced `filter[volume]` filter on GET /service-rates endpoint.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-4674