### PR TITLE
🔥 Final mile carrier country code can be deprecated

### DIFF
--- a/specification/schemas/FinalMileCarrier.json
+++ b/specification/schemas/FinalMileCarrier.json
@@ -3,8 +3,7 @@
   "readOnly": true,
   "required": [
     "name",
-    "tracking_url",
-    "country_code"
+    "tracking_url"
   ],
   "properties": {
     "name": {
@@ -15,9 +14,6 @@
       "type": "string",
       "example": "https://tracker.carrier.com/3SABCD0123456789",
       "description": "URL used to view tracking status updates."
-    },
-    "country_code": {
-      "$ref": "#/components/schemas/CountryCode"
     }
   }
 }


### PR DESCRIPTION
# Changes
Well, the final mile carrier country code can be skipped because it is always the same as the recipient country code.