### PR TITLE
🐛 Avoid readOnly: false

### DIFF
--- a/specification/paths/RegisteredShipments.json
+++ b/specification/paths/RegisteredShipments.json
@@ -25,7 +25,82 @@
             "additionalProperties": false,
             "properties": {
               "data": {
-                "$ref": "#/components/schemas/Shipment"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Shipment"
+                  },
+                  {
+                    "required": [
+                      "attributes",
+                      "relationships"
+                    ],
+                    "properties": {
+                      "id": {
+                        "readOnly": true
+                      },
+                      "attributes": {
+                        "required": [
+                          "recipient_address",
+                          "return_address",
+                          "sender_address",
+                          "physical_properties"
+                        ],
+                        "properties": {
+                          "recipient_address": {
+                            "required": [
+                              "first_name",
+                              "last_name",
+                              "street_1",
+                              "city",
+                              "country_code"
+                            ]
+                          },
+                          "return_address": {
+                            "required": [
+                              "street_1",
+                              "city",
+                              "country_code"
+                            ]
+                          },
+                          "sender_address": {
+                            "required": [
+                              "street_1",
+                              "city",
+                              "country_code"
+                            ]
+                          },
+                          "pickup_location": {
+                            "required": [
+                              "code",
+                              "address"
+                            ]
+                          },
+                          "tracking_code": {
+                            "readOnly": true
+                          },
+                          "physical_properties": {
+                            "required": [
+                              "weight"
+                            ]
+                          },
+                          "items": {
+                            "items": {
+                              "required": [
+                                "description",
+                                "quantity"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "required": [
+                          "shop"
+                        ]
+                      }
+                    }
+                  }
+                ]
               },
               "meta": {
                 "type": "object",

--- a/specification/paths/Shipments-shipment_id.json
+++ b/specification/paths/Shipments-shipment_id.json
@@ -81,7 +81,16 @@
                   {
                     "required": [
                       "id"
-                    ]
+                    ],
+                    "properties": {
+                      "attributes": {
+                        "properties": {
+                          "tracking_code": {
+                            "readOnly": true
+                          }
+                        }
+                      }
+                    }
                   }
                 ]
               },

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -208,6 +208,9 @@
                               "address"
                             ]
                           },
+                          "tracking_code": {
+                            "readOnly": true
+                          },
                           "physical_properties": {
                             "required": [
                               "weight"

--- a/specification/paths/TrackExternalShipment.json
+++ b/specification/paths/TrackExternalShipment.json
@@ -70,9 +70,6 @@
                               "country_code"
                             ]
                           },
-                          "tracking_code": {
-                            "readonly": false
-                          },
                           "physical_properties": {
                             "required": [
                               "weight"

--- a/specification/schemas/TrackingCode.json
+++ b/specification/schemas/TrackingCode.json
@@ -1,5 +1,4 @@
 {
-  "readOnly": true,
   "type": "string",
   "example": "3SABCD0123456789",
   "description": "Code used to request tracking status from the carrier. This is not necessarily the same as the shipment barcode."


### PR DESCRIPTION
- Avoid display issues due to `"readOnly": false`
- Apply POST data restrictions to `POST /registered-shipments` endpoint.