### PR TITLE
👌 Changed latitude/longitude types

### DIFF
--- a/specification/parameters/path-latitude.json
+++ b/specification/parameters/path-latitude.json
@@ -4,6 +4,8 @@
   "description": "Geolocation latitude.",
   "required": true,
   "schema": {
-    "type": "float"
+    "type": "string",
+    "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$",
+    "example": "52.359686"
   }
 }

--- a/specification/parameters/path-longitude.json
+++ b/specification/parameters/path-longitude.json
@@ -4,6 +4,8 @@
   "description": "Geolocation longitude.",
   "required": true,
   "schema": {
-    "type": "float"
+    "type": "string",
+    "pattern": "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$",
+    "example": "4.884573"
   }
 }


### PR DESCRIPTION
# Changes
Basically the `+` and `-` are allowed when specifying geo location, and also there are some ranges in the numbers for both. Therefore I changed the types to string and I have placed a regex I found on stack overflow