### PR TITLE
Patch Collections - Patchable fields in 🥶lections

### DIFF
--- a/specification/paths/Collections-collection_id.json
+++ b/specification/paths/Collections-collection_id.json
@@ -94,12 +94,21 @@
                             "type": "boolean",
                             "example": true,
                             "description": "Indicates whether the collection should be registered with the carrier. Further updates are no longer possible after a successful registration."
+                          },
+                          "address": {
+                            "readOnly": true
+                          },
+                          "collection_time": {
+                            "readOnly": true
                           }
                         }
                       },
                       "relationships": {
                         "properties": {
                           "shop": {
+                            "readOnly": true
+                          },
+                          "contract": {
                             "readOnly": true
                           }
                         }

--- a/specification/schemas/Collection.json
+++ b/specification/schemas/Collection.json
@@ -96,9 +96,6 @@
               "allOf": [
                 {
                   "$ref": "#/components/schemas/ShipmentsRelationship"
-                },
-                {
-                  "readOnly": true
                 }
               ]
             },


### PR DESCRIPTION
# Changes
- Shipments can now be posted as a relationship
- Only the `name` and `register` properties can be patched