### PR TITLE
✨ Idempotency key and replay headers

### DIFF
--- a/specification/parameters.json
+++ b/specification/parameters.json
@@ -2,6 +2,9 @@
   "header-files": {
     "$ref": "./parameters/header-files.json"
   },
+  "header-idempotency-key": {
+    "$ref": "./parameters/header-idempotency-key.json"
+  },
   "path-address_id": {
     "$ref": "./parameters/path-address_id.json"
   },

--- a/specification/parameters/header-idempotency-key.json
+++ b/specification/parameters/header-idempotency-key.json
@@ -1,0 +1,8 @@
+{
+  "name": "Idempotency-Key",
+  "in": "header",
+  "description": "Populate this header with a value <strong>unique to the request data</strong> if you want to prevent duplicate resources when you call this endpoint multiple times, for example due to network issues.",
+  "schema": {
+    "type": "string"
+  }
+}

--- a/specification/paths/RegisteredShipments.json
+++ b/specification/paths/RegisteredShipments.json
@@ -169,9 +169,22 @@
         }
       }
     },
+    "parameters": [
+      {
+        "$ref": "#/components/parameters/header-idempotency-key"
+      }
+    ],
     "responses": {
       "201": {
         "description": "The shipment is created.",
+        "headers": {
+          "Idempotency-Replay": {
+            "description": "Present with value `true` when the response is replayed based on the provided `Idempotency-Key` header.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
         "content": {
           "application/vnd.api+json": {
             "schema": {

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -276,9 +276,22 @@
         }
       }
     },
+    "parameters": [
+      {
+        "$ref": "#/components/parameters/header-idempotency-key"
+      }
+    ],
     "responses": {
       "201": {
         "description": "The shipment is created.",
+        "headers": {
+          "Idempotency-Replay": {
+            "description": "Present with value `true` when the response is replayed based on the provided `Idempotency-Key` header.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
         "content": {
           "application/vnd.api+json": {
             "schema": {


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-4922
---
- Updated  `POST /shipments` and `POST /registered-shipments` endpoints:
  - Added `Idempotency-Key` request header.
  - Added `Idempotency-Replay` response header.