### PR TITLE
🐛 Fix nullable zone state_codes

### DIFF
--- a/specification/schemas/Zone.json
+++ b/specification/schemas/Zone.json
@@ -36,17 +36,17 @@
               "description": "Regular expression matching postal code areas."
             },
             "state_codes": {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
                     "$ref": "#/components/schemas/StateCode"
-                  },
-                  {
-                    "type": "null"
                   }
-                ]
-              }
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "country_codes": {
               "type": "array",


### PR DESCRIPTION
The `state_codes` were defined as:

> an array, containing a StateCode or null

It should be:

> an array containing a StateCode, or null