### PR TITLE
🐛 Multi-colli master shipment should not have weight required

### DIFF
--- a/specification/paths/MultiColliShipments.json
+++ b/specification/paths/MultiColliShipments.json
@@ -48,8 +48,7 @@
                         "required": [
                           "recipient_address",
                           "return_address",
-                          "sender_address",
-                          "physical_properties"
+                          "sender_address"
                         ],
                         "properties": {
                           "recipient_address": {
@@ -83,11 +82,6 @@
                           },
                           "tracking_code": {
                             "readOnly": true
-                          },
-                          "physical_properties": {
-                            "required": [
-                              "weight"
-                            ]
                           },
                           "items": {
                             "items": {


### PR DESCRIPTION
We will handle the weight in our API, based on the weight of each collo (which is required).