### PR TITLE
:sparkles: MP-5174 Add shipment to next collection

### DIFF
--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -246,6 +246,11 @@
               "meta": {
                 "type": "object",
                 "properties": {
+                  "add_to_latest_collection": {
+                    "type": "boolean",
+                    "example": true,
+                    "description": "Adds the shipment to the latest collection. Does nothing if combined with collection relationship."
+                  },
                   "label_mime_type": {
                     "type": "string",
                     "example": "application/pdf",

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -246,10 +246,10 @@
               "meta": {
                 "type": "object",
                 "properties": {
-                  "add_to_latest_collection": {
+                  "add_to_next_collection": {
                     "type": "boolean",
                     "example": true,
-                    "description": "Adds the shipment to the latest collection. Does nothing if combined with collection relationship."
+                    "description": "Adds the shipment to the next collection (collection_time.from is closest to now in the future). Does nothing if combined with collection relationship."
                   },
                   "label_mime_type": {
                     "type": "string",


### PR DESCRIPTION
## Changes 
- Added meta property `add_to_next_collection` to the POST /shipments endpoint.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5174
- https://myparcelcombv.atlassian.net/browse/MP-5037