### PR TITLE
🐛 Fix response path for export-rates-template

### DIFF
--- a/specification/paths/ExportRatesTemplate.json
+++ b/specification/paths/ExportRatesTemplate.json
@@ -48,16 +48,16 @@
             }
           }
         }
-      },
-      "responses": {
-        "200": {
-          "description": "Retrieved the CSV service rates template.",
-          "content": {
-            "text/csv": {
-              "schema": {
-                "type": "string",
-                "description": "Base64 encoded contents of the CSV file."
-              }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "Retrieved the CSV service rates template.",
+        "content": {
+          "text/csv": {
+            "schema": {
+              "type": "string",
+              "description": "Base64 encoded contents of the CSV file."
             }
           }
         }


### PR DESCRIPTION
The response was not visible in the spec because the indentation was wrong.