### PR TITLE
♻️ get-dynamic-service-rates should accept json-api

### DIFF
--- a/specification/paths/CreateManifestForCollection.json
+++ b/specification/paths/CreateManifestForCollection.json
@@ -41,22 +41,22 @@
             }
           }
         }
-      },
-      "responses": {
-        "200": {
-          "description": "The created manifest resource, represented in JSON.",
-          "content": {
-            "application/vnd.api+json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "data"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "data": {
-                    "$ref": "#/components/schemas/ManifestResponse"
-                  }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "The created manifest resource, represented in JSON.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/components/schemas/ManifestResponse"
                 }
               }
             }

--- a/specification/paths/GetDynamicServiceRates.json
+++ b/specification/paths/GetDynamicServiceRates.json
@@ -17,7 +17,7 @@
       "description": "The shipment object with a service and contract.",
       "required": true,
       "content": {
-        "application/json": {
+        "application/vnd.api+json": {
           "schema": {
             "type": "object",
             "required": [
@@ -87,7 +87,7 @@
       "200": {
         "description": "Retrieved the service rates.",
         "content": {
-          "application/json": {
+          "application/vnd.api+json": {
             "schema": {
               "type": "object",
               "required": [


### PR DESCRIPTION
To enable `validate-json` middleware in our API, this endpoint should work with `application/vnd.api+json`.

Also there was an indentation issue in the manifest RPC endpoint, causing the response not to be shown.