### PR TITLE
♻️ RPC endpoints should always work with application/json

### DIFF
--- a/specification/paths/ConsolidateShipments.json
+++ b/specification/paths/ConsolidateShipments.json
@@ -16,7 +16,7 @@
       "description": "The consolidation shipment id and the shipment ids.",
       "required": true,
       "content": {
-        "application/vnd.api+json": {
+        "application/json": {
           "schema": {
             "type": "object",
             "required": [

--- a/specification/paths/CreateManifestForCollection.json
+++ b/specification/paths/CreateManifestForCollection.json
@@ -47,7 +47,7 @@
       "200": {
         "description": "The created manifest resource, represented in JSON.",
         "content": {
-          "application/vnd.api+json": {
+          "application/json": {
             "schema": {
               "type": "object",
               "required": [

--- a/specification/paths/GetDynamicServiceRates.json
+++ b/specification/paths/GetDynamicServiceRates.json
@@ -17,7 +17,7 @@
       "description": "The shipment object with a service and contract.",
       "required": true,
       "content": {
-        "application/vnd.api+json": {
+        "application/json": {
           "schema": {
             "type": "object",
             "required": [
@@ -87,7 +87,7 @@
       "200": {
         "description": "Retrieved the service rates.",
         "content": {
-          "application/vnd.api+json": {
+          "application/json": {
             "schema": {
               "type": "object",
               "required": [

--- a/specification/paths/TrackExternalShipment.json
+++ b/specification/paths/TrackExternalShipment.json
@@ -16,7 +16,7 @@
       "description": "The shipment that should be tracked.",
       "required": true,
       "content": {
-        "application/vnd.api+json": {
+        "application/json": {
           "schema": {
             "type": "object",
             "required": [


### PR DESCRIPTION
After discussing with the team, we should make RPC endpoints work with `application/json` regardless of the actual JSON.
The main reason is consistency and the fact that JSON:API is designed for REST endpoints (which RPC endpoints are not).