### PR TITLE
MP-5128 :fire: Remove registered shipments endpoint from experimental endpoints

### DIFF
--- a/src/myparcelcom.js
+++ b/src/myparcelcom.js
@@ -98,7 +98,6 @@
           'CombinedFiles',
           'Invoices',
           'PasswordResets',
-          'Shipments/paths/~1registered-shipments/post',
           'ShipmentSurcharges',
           'SystemMessages',
           'ExportLoginAttempts'


### PR DESCRIPTION
## Changes
- Removed POST `/registered-shipments` from list of experimental endpoints.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5128