### PR TITLE
📝 423 response for requests which support idempotency

### DIFF
--- a/specification/paths/MultiColliShipments.json
+++ b/specification/paths/MultiColliShipments.json
@@ -287,6 +287,9 @@
       },
       "422": {
         "description": "The shipment could not be created because the carrier did not accept the supplied information."
+      },
+      "423": {
+        "description": "The previous request with the same idempotency key is still being processed."
       }
     }
   }

--- a/specification/paths/RegisterMultiColliShipment.json
+++ b/specification/paths/RegisterMultiColliShipment.json
@@ -278,6 +278,9 @@
             }
           }
         }
+      },
+      "423": {
+        "description": "The previous request with the same idempotency key is still being processed."
       }
     }
   }

--- a/specification/paths/RegisteredShipments.json
+++ b/specification/paths/RegisteredShipments.json
@@ -250,6 +250,9 @@
       },
       "422": {
         "description": "The shipment could not be created because the carrier did not accept the supplied information."
+      },
+      "423": {
+        "description": "The previous request with the same idempotency key is still being processed."
       }
     }
   }

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -312,6 +312,9 @@
             }
           }
         }
+      },
+      "423": {
+        "description": "The previous request with the same idempotency key is still being processed."
       }
     }
   }


### PR DESCRIPTION
When sending another request with the same `Idempotency-Key` header, while the first request is still being processed, you will get a `423` conflict response.