### PR TITLE
♻️ Remove regex from zone country_codes to improve error messages

### DIFF
--- a/specification/schemas/Zone.json
+++ b/specification/schemas/Zone.json
@@ -51,8 +51,10 @@
             "country_codes": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/CountryCode"
-              }
+                "type": "string",
+                "example": "GB"
+              },
+              "description": "List of country codes in ISO 3166-1 alpha-2 format."
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"


### PR DESCRIPTION
We will add API validation to be able to output which country code is invalid.