### PR TITLE
MP-5356 Tracking code on carrier statuses

### DIFF
--- a/specification/schemas/CarrierStatus.json
+++ b/specification/schemas/CarrierStatus.json
@@ -23,6 +23,11 @@
       "type": "integer",
       "example": 1504801719,
       "description": "Unix timestamp (UTC) when the carrier registered this status."
+    },
+    "tracking_code": {
+      "type": "string",
+      "example": "3SABCD0123456789",
+      "description": "The tracking code of the shipment that was used to get this status from the carrier."
     }
   }
 }

--- a/specification/schemas/TrackingCode.json
+++ b/specification/schemas/TrackingCode.json
@@ -1,5 +1,5 @@
 {
   "type": "string",
   "example": "3SABCD0123456789",
-  "description": "Code used to request tracking status from the carrier. This is not necessarily the same as the shipment barcode."
+  "description": "The (currently active) tracking code used to request tracking status from the carrier. This is not necessarily the same as the shipment barcode."
 }


### PR DESCRIPTION
## Changes
- Added `tracking_code` to carrier status schema
- Improved the description of the Shipment's `tracking_code` attribute.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5356
- https://myparcelcombv.atlassian.net/browse/MP-5296