### PR TITLE
:lady_beetle: Added collection-collected to status code enum.

### DIFF
--- a/specification/schemas/Status.json
+++ b/specification/schemas/Status.json
@@ -12,6 +12,7 @@
             "code": {
               "type": "string",
               "enum": [
+                "collection-collected",
                 "collection-concept",
                 "collection-registered",
                 "collection-registration-failed",


### PR DESCRIPTION
## Changes
- We had a randomly failing test in the API that was choosing `collection-collected` as a status, but the API specification didn't have it as a possible value in its enum.