### PR TITLE
:sparkles: MP-5483 Added reference to shop and organization schemas.

### DIFF
--- a/specification/paths/Organizations.json
+++ b/specification/paths/Organizations.json
@@ -17,7 +17,7 @@
       {
         "name": "filter[search]",
         "in": "query",
-        "description": "String of characters you want to look for in a organizations attributes. Available fields to look in are:<ul><li>`Name`</li><li>`Address`</li><li>`Email`</li><li>`Phone`</li></ul>",
+        "description": "String of characters you want to look for in a organizations attributes. Available fields to look in are:<ul><li>`Name`</li><li>`Address`</li><li>`Email`</li><li>`Phone`</li><li>`Reference`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Shops.json
+++ b/specification/paths/Shops.json
@@ -18,7 +18,7 @@
       {
         "name": "filter[search]",
         "in": "query",
-        "description": "String of characters you want to look for in a shops attributes. Available fields to look in are:<ul><li>`Name`</li><li>`Address`</li><li>`Email`</li><li>`Phone`</li></ul>",
+        "description": "String of characters you want to look for in a shops attributes. Available fields to look in are:<ul><li>`Name`</li><li>`Address`</li><li>`Email`</li><li>`Phone`</li><li>`Reference`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/schemas/Organization.json
+++ b/specification/schemas/Organization.json
@@ -74,6 +74,14 @@
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
+            },
+            "reference": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "674864928466",
+              "description": "Any reference to identify the organization."
             }
           }
         },

--- a/specification/schemas/Shop.json
+++ b/specification/schemas/Shop.json
@@ -28,6 +28,14 @@
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
+            },
+            "reference": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "7467",
+              "description": "Any reference to identify the shop."
             }
           }
         },


### PR DESCRIPTION
## Changes
- Added `reference` attribute to shop and organization schemas
- Added `reference` as a field to use when searching organizations or shops

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5370
- https://myparcelcombv.atlassian.net/browse/MP-5483