### PR TITLE
:sparkles: MP-5495 Added item_weight_unit property to shipment items

### DIFF
--- a/specification/schemas/BaseShipmentItem.json
+++ b/specification/schemas/BaseShipmentItem.json
@@ -52,6 +52,15 @@
       "example": 135,
       "description": "Weight in grams of a single item within item resource. Should be multiplied by quantity to get total weight."
     },
+    "item_weight_unit": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "example": "mg",
+      "description": "Unit of measurement for item_weight. Options are: mg, g, kg, oz, lb.",
+      "default": "g"
+    },
     "origin_country_code": {
       "oneOf": [
         {

--- a/specification/schemas/BaseShipmentItem.json
+++ b/specification/schemas/BaseShipmentItem.json
@@ -57,9 +57,16 @@
         "string",
         "null"
       ],
-      "example": "mg",
-      "description": "Unit of measurement for item_weight. Options are: mg, g, kg, oz, lb.",
-      "default": "g"
+      "example": "g",
+      "description": "Unit of measurement for item_weight.",
+      "default": "g",
+      "enum": [
+        "mg",
+        "g",
+        "kg",
+        "oz",
+        "lb"
+      ]
     },
     "origin_country_code": {
       "oneOf": [


### PR DESCRIPTION
## Changes
- Introduced `item_weight_unit` for shipment items.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5495
- https://myparcelcombv.atlassian.net/browse/MP-5254