### PR TITLE
MP-5566 Collection schedule time from and to into timestring

### DIFF
--- a/specification/paths/CollectionSchedules.json
+++ b/specification/paths/CollectionSchedules.json
@@ -12,6 +12,24 @@
     ],
     "summary": "Get all available collection schedules.",
     "description": "This endpoint retrieves collection schedules.",
+    "parameters": [
+      {
+        "name": "filter[shop]",
+        "in": "query",
+        "description": "Shop id to filter the results by.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "filter[carrier]",
+        "in": "query",
+        "description": "Carrier id to filter the results by. Results are filtered by the contract's carrier relationship.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
     "responses": {
       "200": {
         "description": "Retrieved the collection schedules.",

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -83,6 +83,9 @@
   "CollectionScheduleResource": {
     "$ref": "./schemas/CollectionScheduleResource.json"
   },
+  "CollectionScheduleTime": {
+    "$ref": "./schemas/CollectionScheduleTime.json"
+  },
   "CollectionTime": {
     "$ref": "./schemas/CollectionTime.json"
   },

--- a/specification/schemas/CollectionSchedule.json
+++ b/specification/schemas/CollectionSchedule.json
@@ -45,7 +45,7 @@
                   "description": "A description that is given to the created collections."
                 },
                 "time": {
-                  "$ref": "#/components/schemas/CollectionTime"
+                  "$ref": "#/components/schemas/CollectionScheduleTime"
                 },
                 "address": {
                   "allOf": [

--- a/specification/schemas/CollectionScheduleTime.json
+++ b/specification/schemas/CollectionScheduleTime.json
@@ -7,13 +7,15 @@
   "properties": {
     "from": {
       "type": "string",
-      "description": "Time in H:i format indicating the earliest requested time for this collection.",
-      "example": "09:00"
+      "description": "Time string in ISO 8601 format indicating the earliest requested time for this collection. Omitting a timezone will result in UTC time.",
+      "example": "09:00+02:00",
+      "pattern": "^([0-1]\\d|2[0-3]):[0-5]\\d(Z|(\\+|-)\\d?\\d?(:\\d\\d)?)?$"
     },
     "to":{
       "type": "string",
-      "description": "Time in H:i format indicating the latest requested time for this collection.",
-      "example": "12:00"
+      "description": "Time string in ISO 8601 format indicating the latest requested time for this collection. Omitting a timezone will result in UTC time.",
+      "example": "12:00+02:00",
+      "pattern": "^([0-1]\\d|2[0-3]):[0-5]\\d(Z|(\\+|-)\\d?\\d?(:\\d\\d)?)?$"
     }
   }
 }

--- a/specification/schemas/CollectionScheduleTime.json
+++ b/specification/schemas/CollectionScheduleTime.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "required": [
+    "from",
+    "to"
+  ],
+  "properties": {
+    "from": {
+      "type": "string",
+      "description": "Time in H:i format indicating the earliest requested time for this collection.",
+      "example": "09:00"
+    },
+    "to":{
+      "type": "string",
+      "description": "Time in H:i format indicating the latest requested time for this collection.",
+      "example": "12:00"
+    }
+  }
+}


### PR DESCRIPTION
# Changes
- Converted the date time / timestamp attribute into a timestring attribute since we don't need a date for those fields. 