### PR TITLE
:lady_beetle: Fixed mime-type of /combine-files endpoint response.

### DIFF
--- a/specification/paths/CombineFiles.json
+++ b/specification/paths/CombineFiles.json
@@ -70,7 +70,7 @@
       "200": {
         "description": "Created the combined file.",
         "content": {
-          "text/csv": {
+          "text/plain": {
             "schema": {
               "type": "string",
               "description": "Base64 encoded contents of the combined file."


### PR DESCRIPTION
## Changes
The api specification lists that the `/combine-files` RPC endpoint response is `text/csv`. 
This is incorrect, I've changed it to `text/plain`.