### PR TITLE
Revert "Changed shop relationship to owner relationship for Manifests"

### DIFF
--- a/specification/paths/Manifests.json
+++ b/specification/paths/Manifests.json
@@ -17,7 +17,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li><li>`broker`</li><li>`organization`</li><li>`shop`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li></ul>",
         "schema": {
           "type": "string"
         }
@@ -145,19 +145,9 @@
                         }
                       },
                       "relationships": {
-                        "oneOf": [
-                          {
-                            "required": [
-                              "shipments",
-                              "owner"
-                            ]
-                          },
-                          {
-                            "required": [
-                              "shipments",
-                              "shop"
-                            ]
-                          }
+                        "required": [
+                          "shipments",
+                          "shop"
                         ]
                       }
                     }

--- a/specification/schemas/Manifest.json
+++ b/specification/schemas/Manifest.json
@@ -39,33 +39,7 @@
               "$ref": "#/components/schemas/ShipmentsRelationship"
             },
             "shop": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ShopRelationship"
-                },
-                {
-                  "deprecated": true
-                }
-              ]
-            },
-            "owner": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/BrokerRelationship"
-                },
-                {
-                  "$ref": "#/components/schemas/OrganizationRelationship"
-                },
-                {
-                  "$ref": "#/components/schemas/ShopRelationship"
-                }
-              ],
-              "example": {
-                "data": {
-                  "type": "organizations",
-                  "id": "9cdf86e8-333f-4ed9-bb31-4935c780c947"
-                }
-              }
+              "$ref": "#/components/schemas/ShopRelationship"
             },
             "contract": {
               "$ref": "#/components/schemas/ContractRelationship"

--- a/specification/schemas/ManifestIncludes.json
+++ b/specification/schemas/ManifestIncludes.json
@@ -10,15 +10,6 @@
       },
       {
         "$ref": "#/components/schemas/File"
-      },
-      {
-        "$ref": "#/components/schemas/Broker"
-      },
-      {
-        "$ref": "#/components/schemas/Organization"
-      },
-      {
-        "$ref": "#/components/schemas/Shop"
       }
     ]
   }

--- a/specification/schemas/ManifestResponse.json
+++ b/specification/schemas/ManifestResponse.json
@@ -30,7 +30,7 @@
         "relationships": {
           "required": [
             "shipments",
-            "owner"
+            "shop"
           ]
         },
         "links": {


### PR DESCRIPTION
Reverts MyParcelCOM/api-specification#810

Reverting since it's not implemented in the API yet. 
It is currently causing tests to fail in other pull requests that have the updated specification as a dependency. 
We can re-merge it when the functionality in the API is done and until then, development can be done using the dev-branch.