### PR TITLE
:truck: Moved shop-meta inside of top-level data property.

### DIFF
--- a/specification/paths/Shops-shop_id.json
+++ b/specification/paths/Shops-shop_id.json
@@ -90,13 +90,13 @@
                     "properties": {
                       "relationships": {
                         "readOnly": true
+                      },
+                      "meta": {
+                        "$ref": "#/components/schemas/ShopMeta"
                       }
                     }
                   }
                 ]
-              },
-              "meta": {
-                "$ref": "#/components/schemas/ShopMeta"
               }
             }
           }

--- a/specification/paths/Shops.json
+++ b/specification/paths/Shops.json
@@ -164,13 +164,13 @@
                             ]
                           }
                         }
+                      },
+                      "meta": {
+                        "$ref": "#/components/schemas/ShopMeta"
                       }
                     }
                   }
                 ]
-              },
-              "meta": {
-                "$ref": "#/components/schemas/ShopMeta"
               }
             }
           }


### PR DESCRIPTION
In the specification for the request body for post and patch shops, we define the logo contents in a `meta` property that is a sibling of `data`. In other places where we send meta-data with post and patch requests, they reside inside of `data`. (rate-imports, user-scope relationships, and shop-integration relationships). According to the json-api specification, this is allowed and has the following description:

> `meta`: a [meta object](https://jsonapi.org/format/#document-meta) containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.

This sounds a lot like what we're trying to achieve.
Using the top-level `meta` attribute (data's sibling) sounds more like we're sending meta-data about the request instead of the resource. This is also the case for the endpoints for organizations, which is likely why it's also implemented like this in the shop endpoints (copy 🍝 ). Since we're removing this capability of the organization endpoints anyway, what do you guys think about moving the meta-data inside of the `data` property?

I know this might not sound like a huge deal, but it's related to how we prepare data in the back office when posting to the API.
The abstractRepository has a post method that json-serializes the model to be sent and puts all its data in the `data` top level property. If we want to support the top-level meta property, we have to overwrite the abstractRepository's methods to achieve this, which by-the-way is exactly how and why it's currently working for organizations.