### PR TITLE
MP-5922 :sparkles: Added endpoint and schemas for Return Order resources.

### DIFF
--- a/root.json
+++ b/root.json
@@ -41,7 +41,8 @@
               "users.manage": "Manage user resources.",
               "finance.manage": "Manage all finance related resources.",
               "experimental": "Access to experimental endpoints.",
-              "zones.manage": "Manage zone resources."
+              "zones.manage": "Manage zone resources.",
+              "returns.manage": "Manage return resources and related resources."
             }
           }
         }

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -179,6 +179,9 @@
   "/reports/{report_id}/files/{file_id}": {
     "$ref": "./paths/Reports-report_id-Files-file_id.json"
   },
+  "/returns/v1/shops/{shop_id}/orders/{reference}/{email}": {
+    "$ref": "./paths/Returns-v1-shops-shop_id-orders-reference-email.json"
+  },
   "/scopes": {
     "$ref": "./paths/Scopes.json"
   },

--- a/specification/paths/Returns-v1-shops-shop_id-orders-reference-email.json
+++ b/specification/paths/Returns-v1-shops-shop_id-orders-reference-email.json
@@ -1,0 +1,63 @@
+{
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-shop_id"
+    },
+    {
+      "name": "reference",
+      "in": "path",
+      "description": "Order reference to retrieve the order by.",
+      "required": true,
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "email",
+      "in": "path",
+      "description": "Email address of the receiver of the order.",
+      "required": true,
+      "schema": {
+        "$ref": "#/components/schemas/Email"
+      }
+    }
+  ],
+  "get": {
+    "tags": [
+      "Returns"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "returns.manage"
+        ]
+      }
+    ],
+    "summary": "Get an order resource.",
+    "description": "This endpoint retrieves an order resource by the specified reference and email address.",
+    "responses": {
+      "200": {
+        "description": "Retrieved the order.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "No order was found for the given reference and email address."
+      }
+    }
+  }
+}

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -269,6 +269,15 @@
   "MinimalShipmentSurcharge": {
     "$ref": "./schemas/MinimalShipmentSurcharge.json"
   },
+  "Order": {
+    "$ref": "./schemas/Order.json"
+  },
+  "OrderItem": {
+    "$ref": "./schemas/OrderItem.json"
+  },
+  "OrderResource": {
+    "$ref": "./schemas/OrderResource.json"
+  },
   "Organization": {
     "$ref": "./schemas/Organization.json"
   },

--- a/specification/schemas/Order.json
+++ b/specification/schemas/Order.json
@@ -1,0 +1,63 @@
+{
+  "allOf": [
+    {
+      "$ref": "#/components/schemas/OrderResource"
+    },
+    {
+      "required": [
+        "attributes",
+        "relationships"
+      ],
+      "properties": {
+        "attributes": {
+          "type": "object",
+          "required": [
+            "created_at",
+            "recipient_address",
+            "items"
+          ],
+          "properties": {
+            "created_at": {
+              "$ref": "#/components/schemas/Timestamp"
+            },
+            "recipient_address": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BaseAddress"
+                },
+                {
+                  "required": [
+                    "first_name",
+                    "last_name",
+                    "street_1",
+                    "city",
+                    "country_code",
+                    "email"
+                  ]
+                }
+              ]
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OrderItem"
+              }
+            }
+          }
+        },
+        "relationships": {
+          "type": "object",
+          "required": [
+            "shop"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "shop": {
+              "$ref": "#/components/schemas/ShopRelationship"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/specification/schemas/OrderItem.json
+++ b/specification/schemas/OrderItem.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "quantity",
+    "name",
+    "description"
+  ],
+  "properties": {
+    "sku": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "example": "123456789"
+    },
+    "name": {
+      "type": "string",
+      "example": "OnePlus X"
+    },
+    "description": {
+      "type": "string",
+      "example": "Latest OnePlus X model for making the best phone calls imaginable!"
+    },
+    "image_url": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "example": "https://myparcel.com/product.png",
+      "description": "A link to an image of the item."
+    },
+    "quantity": {
+      "type": "integer",
+      "example": 2
+    },
+    "item_weight": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "example": 135,
+      "description": "Weight in grams of a single item within item resource. Should be multiplied by quantity to get total weight."
+    },
+    "item_weight_unit": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "example": "g",
+      "description": "Unit of measurement for item_weight.",
+      "default": "g",
+      "enum": [
+        "mg",
+        "g",
+        "kg",
+        "oz",
+        "lb"
+      ]
+    }
+  }
+}

--- a/specification/schemas/OrderResource.json
+++ b/specification/schemas/OrderResource.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "required": [
+    "type",
+    "id"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "pattern": "^orders$",
+      "example": "orders"
+    },
+    "id": {
+      "type": "string",
+      "example": "#this-is-my-reference-001",
+      "description": "The reference by which this order can be retrieved from its source."
+    }
+  }
+}

--- a/specification/tags.json
+++ b/specification/tags.json
@@ -126,6 +126,10 @@
     }
   },
   {
+    "name": "Returns",
+    "externalDocs": {}
+  },
+  {
     "name": "Scopes",
     "externalDocs": {
     }

--- a/src/myparcelcom.js
+++ b/src/myparcelcom.js
@@ -100,7 +100,8 @@
           'PasswordResets',
           'ShipmentSurcharges',
           'SystemMessages',
-          'ExportLoginAttempts'
+          'ExportLoginAttempts',
+          "Returns"
         ]
         for (var i = 0; i < internal.length; i++) {
           var sections = document.querySelectorAll([


### PR DESCRIPTION
## Changes
- ✨ Added schema's for the Order resource and it's related schema's.
- ✨ Added the endpoint for retrieving orders
- ✨ Added the `returns.manage` scope to the list of scopes.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5922
- https://myparcelcombv.atlassian.net/browse/MP-5754