### PR TITLE
🪲 Fix owner include on manifest endpoints

### DIFF
--- a/specification/paths/Manifests-manifest_id.json
+++ b/specification/paths/Manifests-manifest_id.json
@@ -22,7 +22,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li><li>`owner`</li><li><strike>`shop`</strike></li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Manifests.json
+++ b/specification/paths/Manifests.json
@@ -17,7 +17,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li><li>`broker`</li><li>`organization`</li><li>`shop`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`files`</li><li>`contract`</li><li>`contract.carrier`</li><li>`owner`</li><li><strike>`shop`</strike></li></ul>",
         "schema": {
           "type": "string"
         }
@@ -150,9 +150,15 @@
                             "required": [
                               "shipments",
                               "owner"
-                            ]
+                            ],
+                            "properties": {
+                              "shop": {
+                                "readOnly": true
+                              }
+                            }
                           },
                           {
+                            "deprecated": true,
                             "required": [
                               "shipments",
                               "shop"

--- a/specification/schemas/Manifest.json
+++ b/specification/schemas/Manifest.json
@@ -35,19 +35,6 @@
                 }
               ]
             },
-            "shipments": {
-              "$ref": "#/components/schemas/ShipmentsRelationship"
-            },
-            "shop": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ShopRelationship"
-                },
-                {
-                  "deprecated": true
-                }
-              ]
-            },
             "owner": {
               "oneOf": [
                 {
@@ -66,6 +53,19 @@
                   "id": "9cdf86e8-333f-4ed9-bb31-4935c780c947"
                 }
               }
+            },
+            "shipments": {
+              "$ref": "#/components/schemas/ShipmentsRelationship"
+            },
+            "shop": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ShopRelationship"
+                },
+                {
+                  "deprecated": true
+                }
+              ]
             },
             "contract": {
               "$ref": "#/components/schemas/ContractRelationship"


### PR DESCRIPTION
- The include should be `owner` instead of `broker` or `organization` (or `shop` which is not deprecated).
- Made the `shop` readOnly in the schema which contains `owner`, so they cannot be posted together.
- Moved the `owner` relationship up so it's above the deprecated `shop` relationship.