### PR TITLE
🧵 Allow both owner and shop in the manifest response relationships

### DIFF
--- a/specification/paths/Manifests.json
+++ b/specification/paths/Manifests.json
@@ -162,7 +162,12 @@
                             "required": [
                               "shipments",
                               "shop"
-                            ]
+                            ],
+                            "properties": {
+                              "owner": {
+                                "readOnly": true
+                              }
+                            }
                           }
                         ]
                       }

--- a/specification/schemas/ManifestResponse.json
+++ b/specification/schemas/ManifestResponse.json
@@ -28,7 +28,7 @@
           }
         },
         "relationships": {
-          "oneOf": [
+          "anyOf": [
             {
               "required": [
                 "shipments",


### PR DESCRIPTION
API tests `Failed to match exactly one schema` in a manifest response, which is enforced by `oneOf` so we better use `anyOf`.