### PR TITLE
:beetle: Return response required fields

### DIFF
--- a/specification/schemas/ReturnResponse.json
+++ b/specification/schemas/ReturnResponse.json
@@ -13,8 +13,9 @@
       "properties": {
         "attributes": {
           "required": [
-            "name",
-            "filters",
+            "order_reference",
+            "consumer_address",
+            "items",
             "created_at"
           ]
         },


### PR DESCRIPTION
# Changes
- Removed badly copied properties from the required fields
- Introduced response fields that should actually be required