### PR TITLE
:heavy_plus_sign: Introduced identifiers for Order item and Return item

### DIFF
--- a/specification/schemas/OrderItem.json
+++ b/specification/schemas/OrderItem.json
@@ -2,11 +2,16 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "id",
     "quantity",
     "name",
     "description"
   ],
   "properties": {
+    "id": {
+      "type": "string",
+      "example": "7fac478b-b3c4-46e6-b29e-a31599d27a7a"
+    },
     "sku": {
       "type": [
         "string",

--- a/specification/schemas/ReturnItem.json
+++ b/specification/schemas/ReturnItem.json
@@ -9,7 +9,7 @@
   "properties": {
     "id": {
       "type": "string",
-      "example": "7fac478b-b3c4-46e6-b29e-a31599d27a7a"
+      "example": "380e31a1-cf15-46d6-b131-7ca0ff0a4013"
     },
     "sku": {
       "type": [

--- a/specification/schemas/ReturnItem.json
+++ b/specification/schemas/ReturnItem.json
@@ -2,11 +2,15 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "id",
     "quantity",
-    "name",
     "description"
   ],
   "properties": {
+    "id": {
+      "type": "string",
+      "example": "7fac478b-b3c4-46e6-b29e-a31599d27a7a"
+    },
     "sku": {
       "type": [
         "string",


### PR DESCRIPTION
# Changes
- Introduced identifiers for Order item and Return item
- Removed name as required  property from the Return item since we can now identify by id.