### PR TITLE
:sparkles: Added filters to the contracts endpoint.

### DIFF
--- a/specification/parameters.json
+++ b/specification/parameters.json
@@ -134,6 +134,9 @@
   "query-filter-carrier": {
     "$ref": "./parameters/query-filter-carrier.json"
   },
+  "query-filter-owner": {
+    "$ref": "./parameters/query-filter-owner.json"
+  },
   "query-filter-created_at-date_from": {
     "$ref": "./parameters/query-filter-created_at-date_from.json"
   },

--- a/specification/parameters/query-filter-owner.json
+++ b/specification/parameters/query-filter-owner.json
@@ -1,0 +1,8 @@
+{
+  "name": "filter[owner]",
+  "in": "query",
+  "description": "Comma separated string of owner ids to filter by.",
+  "schema": {
+    "type": "string"
+  }
+}

--- a/specification/paths/Contracts.json
+++ b/specification/paths/Contracts.json
@@ -40,7 +40,7 @@
       {
         "name": "filter[status]",
         "in": "query",
-        "description": "Comma separated string of the status of the contract you want to filter on.<br>The statuses that can be filtered on are:<ul><li>`active`</li><li>`inactive`</li><li>`inactive`</li><li>`pending`</li></ul>",
+        "description": "Comma separated string of the status of the contract you want to filter on.<br>The statuses that can be filtered on are:<ul><li>`active`</li><li>`inactive`</li><li>`invalid`</li><li>`pending`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Contracts.json
+++ b/specification/paths/Contracts.json
@@ -22,6 +22,28 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "filter[search]",
+        "in": "query",
+        "description": "String of characters you want to look for in a contract's attributes.<br>Contracts that have the string in their `name` attribute or their `owner`'s `name` attribute will be returned.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-carrier"
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-owner"
+      },
+      {
+        "name": "filter[status]",
+        "in": "query",
+        "description": "Comma separated string of the status of the contract you want to filter on.<br>The statuses that can be filtered on are:<ul><li>`active`</li><li>`inactive`</li><li>`inactive`</li><li>`pending`</li></ul>",
+        "schema": {
+          "type": "string"
+        }
       }
     ],
     "responses": {

--- a/specification/schemas/ManifestResource.json
+++ b/specification/schemas/ManifestResource.json
@@ -3,6 +3,7 @@
   "required": [
     "type"
   ],
+  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",


### PR DESCRIPTION
## Changes
- While working on the back office, I wanted to see what filters we have available on the GET /Contracts endpoint. To my surprise, the spec didn't have any listed. So I added the ones that are available according to the `ContractRepository` in our API.
![image](https://github.com/MyParcelCOM/api-specification/assets/32866117/b7ac49f6-8f40-421a-8a5a-ac2497260b17)
