### PR TITLE
🐛 No additionalProperties false on the ManifestResource

### DIFF
--- a/specification/schemas/ManifestResource.json
+++ b/specification/schemas/ManifestResource.json
@@ -3,7 +3,6 @@
   "required": [
     "type"
   ],
-  "additionalProperties": false,
   "properties": {
     "type": {
       "type": "string",


### PR DESCRIPTION
The `ManifestResource` is a generic resource which is extended with `attributes` and `relationships` by other resources.
Giving this `"additionalProperties": false` causes errors in our API on the manifest `getAll` response.
Since the inheritance of the additionalProperties between resources does not work as expected, we better revert and remove this.