### PR TITLE
⏪️ ShopIntegration meta.settings should not be required

### DIFF
--- a/specification/paths/Shops-shop_id-relationships-integrations.json
+++ b/specification/paths/Shops-shop_id-relationships-integrations.json
@@ -90,9 +90,6 @@
                     "items": {
                       "properties": {
                         "meta": {
-                          "required": [
-                            "settings"
-                          ],
                           "properties": {
                             "settings": {
                               "type": "object",


### PR DESCRIPTION
Since the integration `settings_format` is optional/nullable, the shop relationship meta should also not have `settings` required.