### PR TITLE
🐛 Fix refactoring issue in the ContractsRelationship schema

### DIFF
--- a/specification/schemas/ContractsRelationship.json
+++ b/specification/schemas/ContractsRelationship.json
@@ -7,7 +7,16 @@
     "data": {
       "type": "array",
       "items": {
-        "$ref": "#/components/schemas/ContractResponse"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ContractResource"
+          },
+          {
+            "required": [
+              "id"
+            ]
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
This was refactored to `ContractResponse`, but it should have been `ContractResource`.