### PR TITLE
🐞 Separate contract status enum values

### DIFF
--- a/specification/schemas/Contract.json
+++ b/specification/schemas/Contract.json
@@ -19,11 +19,8 @@
               "type": "string",
               "enum": [
                 "active",
-                "inactive",
-                "invalid",
-                "pending"
-              ],
-              "description": "A new contract is pending until the `credentials` have been verified. The verification process is done automatically."
+                "inactive"
+              ]
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"

--- a/specification/schemas/ContractResponse.json
+++ b/specification/schemas/ContractResponse.json
@@ -18,7 +18,17 @@
             "status",
             "created_at",
             "updated_at"
-          ]
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "invalid",
+                "pending"
+              ],
+              "description": "A new contract is pending until the `credentials` have been verified. The verification process is done automatically."
+            }
+          }
         },
         "relationships": {
           "required": [


### PR DESCRIPTION
A contract status can have 4 different values, but can only be patched to `active` or `inactive`.

Since the statuses `pending` and `invalid` are set by our API, they belong in the `ContractResponse` schema.

The OpenAPI `allOf` will merge everything so that the final response schema has all 4 values.