### PR TITLE
🐛 Merged enums do not work properly with our validation library

### DIFF
--- a/specification/paths/Contracts-contract_id.json
+++ b/specification/paths/Contracts-contract_id.json
@@ -92,6 +92,12 @@
                     "properties": {
                       "attributes": {
                         "properties": {
+                          "status": {
+                            "enum": [
+                              "active",
+                              "inactive"
+                            ]
+                          },
                           "credentials": {
                             "type": "object",
                             "example": {

--- a/specification/schemas/Contract.json
+++ b/specification/schemas/Contract.json
@@ -17,10 +17,7 @@
             },
             "status": {
               "type": "string",
-              "enum": [
-                "active",
-                "inactive"
-              ]
+              "example": "active"
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"

--- a/specification/schemas/ContractResponse.json
+++ b/specification/schemas/ContractResponse.json
@@ -21,8 +21,9 @@
           ],
           "properties": {
             "status": {
-              "type": "string",
               "enum": [
+                "active",
+                "inactive",
                 "invalid",
                 "pending"
               ],


### PR DESCRIPTION
Defined the enum values in 2 places because our validation library does not recognize merged enum values through `allOf`.