### PR TITLE
:truck: Removed shop id from returns endpoints.

### DIFF
--- a/specification/paths.json
+++ b/specification/paths.json
@@ -182,17 +182,17 @@
   "/returns/v1/shops/{shop_id}/orders/{reference}/{email}": {
     "$ref": "./paths/Returns-v1-shops-shop_id-orders-reference-email.json"
   },
-  "/returns/v1/shops/{shop_id}/returns": {
-    "$ref": "./paths/Returns-v1-shops-shop_id-returns.json"
+  "/returns/v1/returns": {
+    "$ref": "./paths/Returns-v1-returns.json"
   },
-  "/returns/v1/shops/{shop_id}/returns/{return_id}": {
-    "$ref": "./paths/Returns-v1-shops-shop_id-returns-return_id.json"
+  "/returns/v1/returns/{return_id}": {
+    "$ref": "./paths/Returns-v1-returns-return_id.json"
   },
-  "/returns/v1/shops/{shop_id}/returns/{return_id}/approve": {
-    "$ref": "./paths/Returns-v1-shops-shop_id-returns-return_id-approve.json"
+  "/returns/v1/returns/{return_id}/approve": {
+    "$ref": "./paths/Returns-v1-returns-return_id-approve.json"
   },
-  "/returns/v1/shops/{shop_id}/returns/{return_id}/reject": {
-    "$ref": "./paths/Returns-v1-shops-shop_id-returns-return_id-reject.json"
+  "/returns/v1/returns/{return_id}/reject": {
+    "$ref": "./paths/Returns-v1-returns-return_id-reject.json"
   },
   "/scopes": {
     "$ref": "./paths/Scopes.json"

--- a/specification/paths/Returns-v1-returns-return_id-approve.json
+++ b/specification/paths/Returns-v1-returns-return_id-approve.json
@@ -1,4 +1,9 @@
 {
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-return_id"
+    }
+  ],
   "post": {
     "tags": [
       "Returns"
@@ -10,11 +15,11 @@
         ]
       }
     ],
-    "summary": "Reject a return.",
-    "description": "This endpoint modifies the status of a return resource to `return-rejected`",
+    "summary": "Approve a return.",
+    "description": "This endpoint modifies the status of a return resource to `return-approved`",
     "responses": {
       "204": {
-        "description": "The return is rejected."
+        "description": "The return is approved."
       },
       "404": {
         "description": "No return was found for the given id."

--- a/specification/paths/Returns-v1-returns-return_id-reject.json
+++ b/specification/paths/Returns-v1-returns-return_id-reject.json
@@ -1,4 +1,9 @@
 {
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-return_id"
+    }
+  ],
   "post": {
     "tags": [
       "Returns"
@@ -10,11 +15,11 @@
         ]
       }
     ],
-    "summary": "Approve a return.",
-    "description": "This endpoint modifies the status of a return resource to `return-approved`",
+    "summary": "Reject a return.",
+    "description": "This endpoint modifies the status of a return resource to `return-rejected`",
     "responses": {
       "204": {
-        "description": "The return is approved."
+        "description": "The return is rejected."
       },
       "404": {
         "description": "No return was found for the given id."

--- a/specification/paths/Returns-v1-returns-return_id.json
+++ b/specification/paths/Returns-v1-returns-return_id.json
@@ -1,9 +1,6 @@
 {
   "parameters": [
     {
-      "$ref": "#/components/parameters/path-shop_id"
-    },
-    {
       "$ref": "#/components/parameters/path-return_id"
     }
   ],

--- a/specification/paths/Returns-v1-returns.json
+++ b/specification/paths/Returns-v1-returns.json
@@ -31,6 +31,9 @@
       },
       {
         "$ref": "#/components/parameters/query-filter-status"
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-shop"
       }
     ],
     "responses": {


### PR DESCRIPTION
## Changes
- 🔥 🚚 Removed `/shops/{shop_id}` from the returns endpoints (except the order endpoint).

## Reasoning
There's no reason for these endpoints to have the shop id in the path. 
It only causes more inconvenience when wanting to retrieve or create returns.
For example, in the back office, we'd have to fire multiple requests in order for a merchant to view returns for all of their shops. 