### PR TITLE
:sparkles: Made shop relationship required on POST /returns

### DIFF
--- a/specification/paths/Returns-v1-returns.json
+++ b/specification/paths/Returns-v1-returns.json
@@ -131,7 +131,8 @@
                   },
                   {
                     "required": [
-                      "attributes"
+                      "attributes",
+                      "relationships"
                     ],
                     "properties": {
                       "id": {
@@ -154,7 +155,14 @@
                         }
                       },
                       "relationships": {
-                        "readOnly": true
+                        "required": [
+                          "shop"
+                        ],
+                        "properties": {
+                          "status": {
+                            "readOnly": true
+                          }
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
## Changes
- Since the shop id is gone from the url, the POST /returns body should include the shop relationsip.