### PR TITLE
🆔 Endpoint to get PUDO location by ID

### DIFF
--- a/specification/parameters.json
+++ b/specification/parameters.json
@@ -74,6 +74,9 @@
   "path-postal_code": {
     "$ref": "./parameters/path-postal_code.json"
   },
+  "path-pudo_id": {
+    "$ref": "./parameters/path-pudo_id.json"
+  },
   "path-rates_import_id": {
     "$ref": "./parameters/path-rates_import_id.json"
   },

--- a/specification/parameters/path-pudo_id.json
+++ b/specification/parameters/path-pudo_id.json
@@ -1,0 +1,11 @@
+{
+  "name": "pudo_id",
+  "in": "path",
+  "description": "ID of the PickupDropoffLocation.",
+  "required": true,
+  "schema": {
+    "type": "string",
+    "description": "The carrier id and the location's code separated by an underscore (_).",
+    "example": "be7f6752-34e0-49a1-a832-bcc209450ea9_205604"
+  }
+}

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -35,6 +35,9 @@
   "/carriers/{carrier_id}/contracts": {
     "$ref": "./paths/Carriers-carrier_id-Contracts.json"
   },
+  "/carriers/{carrier_id}/pickup-dropoff-locations/{pudo_id}": {
+    "$ref": "./paths/Carriers-carrier_id-PickupDropoffLocations-pudo_id.json"
+  },
   "/carriers/{carrier_id}/pickup-dropoff-locations/{latitude}/{longitude}": {
     "$ref": "./paths/Carriers-carrier_id-PickupDropoffLocations-latitude-longitude.json"
   },

--- a/specification/paths/Carriers-carrier_id-PickupDropoffLocations-pudo_id.json
+++ b/specification/paths/Carriers-carrier_id-PickupDropoffLocations-pudo_id.json
@@ -1,0 +1,58 @@
+{
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-carrier_id"
+    },
+    {
+      "$ref": "#/components/parameters/path-pudo_id"
+    }
+  ],
+  "get": {
+    "tags": [
+      "Carriers"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+        ]
+      }
+    ],
+    "summary": "Get an office location from a carrier by ID.",
+    "description": "This endpoint retrieves the pick-up and drop-off location with the supplied ID.",
+    "responses": {
+      "200": {
+        "description": "Retrieved the location.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data",
+                "meta",
+                "links"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PickupDropoffLocation"
+                    },
+                    {
+                      "required": [
+                        "id"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "No location was found for the given ID. Does this carrier support getting PUDO by ID?"
+      }
+    }
+  }
+}

--- a/specification/schemas/Carrier.json
+++ b/specification/schemas/Carrier.json
@@ -81,19 +81,29 @@
               "properties": {
                 "offers_collections": {
                   "type": "boolean",
-                  "default": false,
-                  "example": false
+                  "default": false
                 },
                 "voids_registered_collections": {
                   "type": "boolean",
                   "description": "Whether the carrier supports voiding of registered collections.",
-                  "example": false
+                  "default": false
                 },
                 "allows_adding_registered_shipments_to_collection": {
                   "type": "boolean",
                   "description": "Whether the carrier supports adding registered shipments to a concept collection.",
-                  "default": false,
-                  "example": false
+                  "default": false
+                }
+              }
+            },
+            "pudo": {
+              "type": "object",
+              "required": [
+                "can_get_pudo_by_id"
+              ],
+              "properties": {
+                "can_get_pudo_by_id": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             }

--- a/specification/schemas/PickupDropoffLocation.json
+++ b/specification/schemas/PickupDropoffLocation.json
@@ -157,6 +157,21 @@
               "$ref": "#/components/schemas/CarrierRelationship"
             }
           }
+        },
+        "links": {
+          "readOnly": true,
+          "type": "object",
+          "required": [
+            "self"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "self": {
+              "type": "string",
+              "format": "url",
+              "example": "$API_HOST/carriers/be7f6752-34e0-49a1-a832-bcc209450ea9/pickup-dropoff-locations/be7f6752-34e0-49a1-a832-bcc209450ea9_205604"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-5565
---
- Added carrier attribute: `pudo.can_get_pudo_by_id`
- Added endpoint: `GET /carriers/{carrier_id}/pickup-dropoff-locations/{pudo_id}`
- Added `self` link to pudo resource.