### PR TITLE
Make return method required

### DIFF
--- a/specification/paths/Returns-v1-returns.json
+++ b/specification/paths/Returns-v1-returns.json
@@ -156,7 +156,8 @@
                       },
                       "relationships": {
                         "required": [
-                          "shop"
+                          "shop",
+                          "return_method"
                         ],
                         "properties": {
                           "status": {

--- a/specification/schemas/ReturnMethodResponse.json
+++ b/specification/schemas/ReturnMethodResponse.json
@@ -18,7 +18,8 @@
         },
         "relationships": {
           "required": [
-            "shop"
+            "shop",
+            "return_method"
           ]
         },
         "links": {


### PR DESCRIPTION
# Changes
- Make return method relationship required on returns


This was optional before so it wouldnt introduce failing tests while developing the API part for this feature.