### PR TITLE
🐛 Make the correct return_method relationship required

### DIFF
--- a/specification/paths/Returns-v1-returns.json
+++ b/specification/paths/Returns-v1-returns.json
@@ -156,8 +156,8 @@
                       },
                       "relationships": {
                         "required": [
-                          "shop",
-                          "return_method"
+                          "return_method",
+                          "shop"
                         ],
                         "properties": {
                           "status": {

--- a/specification/schemas/Return.json
+++ b/specification/schemas/Return.json
@@ -45,14 +45,14 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "status": {
-              "$ref": "#/components/schemas/StatusRelationship"
+            "return_method": {
+              "$ref": "#/components/schemas/ReturnMethodRelationship"
             },
             "shop": {
               "$ref": "#/components/schemas/ShopRelationship"
             },
-            "return_method": {
-              "$ref": "#/components/schemas/ReturnMethodRelationship"
+            "status": {
+              "$ref": "#/components/schemas/StatusRelationship"
             }
           }
         }

--- a/specification/schemas/ReturnMethodResponse.json
+++ b/specification/schemas/ReturnMethodResponse.json
@@ -18,8 +18,7 @@
         },
         "relationships": {
           "required": [
-            "shop",
-            "return_method"
+            "shop"
           ]
         },
         "links": {

--- a/specification/schemas/ReturnResponse.json
+++ b/specification/schemas/ReturnResponse.json
@@ -21,6 +21,7 @@
         },
         "relationships": {
           "required": [
+            "return_method",
             "shop",
             "status"
           ]


### PR DESCRIPTION
The `return_method` relationship on a `ReturnMethodResponse` was required, but this needed to be set on a `ReturnResponse`.

I also updated the relationships to be in alphabetical order.