### PR TITLE
0️⃣ Prevent quantity and item_weight to be 0

### DIFF
--- a/specification/schemas/BaseShipmentItem.json
+++ b/specification/schemas/BaseShipmentItem.json
@@ -23,6 +23,7 @@
     },
     "quantity": {
       "type": "integer",
+      "minimum": 1,
       "example": 2
     },
     "item_value": {
@@ -40,6 +41,7 @@
         "integer",
         "null"
       ],
+      "minimum": 1,
       "example": 135,
       "description": "Weight in grams of a single item within item resource. Should be multiplied by quantity to get total weight."
     },
@@ -107,8 +109,8 @@
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 100,
+      "minimum": 0,
+      "maximum": 100,
       "example": 19,
       "description": "The VAT rate applied to the `item_value` amount."
     },


### PR DESCRIPTION
This will prevent issues in DPD NL when weight calculations are not expecting `0`.

![Screenshot from 2023-09-06 11-15-25](https://github.com/MyParcelCOM/api-specification/assets/4649537/11c10275-9117-4157-a14f-3386680d94ef)
