### PR TITLE
🕴️ Properly distinguish the required scopes

### DIFF
--- a/specification/paths/AddShipmentsToCollection.json
+++ b/specification/paths/AddShipmentsToCollection.json
@@ -6,8 +6,12 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
           "collections.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
         ]
       }
     ],

--- a/specification/paths/Addresses-address_id.json
+++ b/specification/paths/Addresses-address_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Addresses.json
+++ b/specification/paths/Addresses.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Brokers-broker_id-carriers.json
+++ b/specification/paths/Brokers-broker_id-carriers.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "broker.member",
+          "broker.member"
+        ]
+      },
+      {
+        "OAuth2": [
           "enterprise.manage"
         ]
       }

--- a/specification/paths/Brokers-broker_id.json
+++ b/specification/paths/Brokers-broker_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "broker.member",
+          "broker.member"
+        ]
+      },
+      {
+        "OAuth2": [
           "enterprises.manage"
         ]
       }

--- a/specification/paths/Brokers.json
+++ b/specification/paths/Brokers.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "broker.member",
+          "broker.member"
+        ]
+      },
+      {
+        "OAuth2": [
           "enterprises.manage"
         ]
       }

--- a/specification/paths/Collections-collection_id.json
+++ b/specification/paths/Collections-collection_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Collections.json
+++ b/specification/paths/Collections.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "collections.manage",
+          "collections.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "collections.view"
         ]
       }

--- a/specification/paths/CombineFiles.json
+++ b/specification/paths/CombineFiles.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/CombinedFiles-combined_file_id.json
+++ b/specification/paths/CombinedFiles-combined_file_id.json
@@ -12,7 +12,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/CombinedFiles.json
+++ b/specification/paths/CombinedFiles.json
@@ -7,7 +7,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }
@@ -83,7 +87,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Contracts-contract_id.json
+++ b/specification/paths/Contracts-contract_id.json
@@ -11,8 +11,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Contracts.json
+++ b/specification/paths/Contracts.json
@@ -6,8 +6,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/CountReportEntries.json
+++ b/specification/paths/CountReportEntries.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Enterprises-enterprise_id.json
+++ b/specification/paths/Enterprises-enterprise_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "broker.member",
+          "broker.member"
+        ]
+      },
+      {
+        "OAuth2": [
           "enterprises.manage"
         ]
       }

--- a/specification/paths/Enterprises.json
+++ b/specification/paths/Enterprises.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "broker.member",
+          "broker.member"
+        ]
+      },
+      {
+        "OAuth2": [
           "enterprises.manage"
         ]
       }

--- a/specification/paths/Files-file_id.json
+++ b/specification/paths/Files-file_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/GetCarrierStatusCategories.json
+++ b/specification/paths/GetCarrierStatusCategories.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/GetDynamicServiceRates.json
+++ b/specification/paths/GetDynamicServiceRates.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/HookLogs-hook_log_id.json
+++ b/specification/paths/HookLogs-hook_log_id.json
@@ -11,8 +11,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Hooks-hook_id-logs.json
+++ b/specification/paths/Hooks-hook_id-logs.json
@@ -11,8 +11,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Hooks-hook_id.json
+++ b/specification/paths/Hooks-hook_id.json
@@ -11,8 +11,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }
@@ -48,7 +56,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }
@@ -118,7 +130,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Hooks.json
+++ b/specification/paths/Hooks.json
@@ -6,8 +6,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }
@@ -113,7 +121,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/LiabilityCoverage-liability_coverage_id.json
+++ b/specification/paths/LiabilityCoverage-liability_coverage_id.json
@@ -11,8 +11,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Manifests-manifest_id-Files-file_id.json
+++ b/specification/paths/Manifests-manifest_id-Files-file_id.json
@@ -14,7 +14,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Manifests-manifest_id.json
+++ b/specification/paths/Manifests-manifest_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Manifests.json
+++ b/specification/paths/Manifests.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Organizations-organization_id.json
+++ b/specification/paths/Organizations-organization_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Organizations.json
+++ b/specification/paths/Organizations.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Reports-report_id-Files-file_id.json
+++ b/specification/paths/Reports-report_id-Files-file_id.json
@@ -14,7 +14,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Reports-report_id.json
+++ b/specification/paths/Reports-report_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }
@@ -59,7 +63,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Reports.json
+++ b/specification/paths/Reports.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }
@@ -93,7 +97,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Returns-v1-reasons.json
+++ b/specification/paths/Returns-v1-reasons.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "returns.manage",
+          "returns.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "return_reasons.manage"
         ]
       }

--- a/specification/paths/ServiceRates-service_rate_id.json
+++ b/specification/paths/ServiceRates-service_rate_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Shipments-shipment_id-Files.json
+++ b/specification/paths/Shipments-shipment_id-Files.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shipments-shipment_id-Statuses-shipment_status_id.json
+++ b/specification/paths/Shipments-shipment_id-Statuses-shipment_status_id.json
@@ -14,7 +14,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shipments-shipment_id-Statuses.json
+++ b/specification/paths/Shipments-shipment_id-Statuses.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shipments-shipment_id-Surcharges-shipment_surcharge_id.json
+++ b/specification/paths/Shipments-shipment_id-Surcharges-shipment_surcharge_id.json
@@ -14,7 +14,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shipments-shipment_id-Surcharges.json
+++ b/specification/paths/Shipments-shipment_id-Surcharges.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shipments-shipment_id.json
+++ b/specification/paths/Shipments-shipment_id.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -6,7 +6,11 @@
     "security": [
       {
         "OAuth2": [
-          "shipments.manage",
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shops-shop_id-integrations-integration_id-shipments.json
+++ b/specification/paths/Shops-shop_id-integrations-integration_id-shipments.json
@@ -22,7 +22,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Shops-shop_id-integrations.json
+++ b/specification/paths/Shops-shop_id-integrations.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Shops-shop_id-relationships-integrations.json
+++ b/specification/paths/Shops-shop_id-relationships-integrations.json
@@ -11,7 +11,11 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.manage"
         ]
       }

--- a/specification/paths/Shops-shop_id.json
+++ b/specification/paths/Shops-shop_id.json
@@ -11,8 +11,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }

--- a/specification/paths/Shops.json
+++ b/specification/paths/Shops.json
@@ -6,8 +6,16 @@
     "security": [
       {
         "OAuth2": [
-          "organizations.manage",
-          "shipments.manage",
+          "organizations.manage"
+        ]
+      },
+      {
+        "OAuth2": [
+          "shipments.manage"
+        ]
+      },
+      {
+        "OAuth2": [
           "shipments.view"
         ]
       }


### PR DESCRIPTION
Properly distinguish if **all** or **any** of the scopes is required to access the endpoint.
Almost all of our endpoints only require 1 of the scopes, therefore we need separate "security" entries.