### PR TITLE
:beetle: Remove required return reason relationships on post

### DIFF
--- a/specification/paths/Returns-v1-reasons.json
+++ b/specification/paths/Returns-v1-reasons.json
@@ -121,8 +121,7 @@
                   },
                   {
                     "required": [
-                      "attributes",
-                      "relationships"
+                      "attributes"
                     ],
                     "properties": {
                       "id": {

--- a/specification/paths/Returns-v1-reasons.json
+++ b/specification/paths/Returns-v1-reasons.json
@@ -15,14 +15,6 @@
     "description": "This endpoint retrieves returns reasons available to your API client.",
     "parameters": [
       {
-        "name": "include",
-        "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`shop`</li></ul>",
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
         "$ref": "#/components/parameters/query-filter-tags"
       }
     ],
@@ -134,11 +126,6 @@
                           "requires_attachments"
                         ]
                       },
-                      "relationships": {
-                        "required": [
-                          "shop"
-                        ]
-                      }
                     }
                   }
                 ]


### PR DESCRIPTION
# Changes
- No relationships are required when creating a return reason 