### PR TITLE
:mute: Hide the return reason management under its own tag

### DIFF
--- a/specification/paths/Returns-v1-reasons-return_reason_id.json
+++ b/specification/paths/Returns-v1-reasons-return_reason_id.json
@@ -6,7 +6,7 @@
   ],
   "get": {
     "tags": [
-      "ReturnReasons"
+      "ReturnReasonsManagement"
     ],
     "security": [
       {
@@ -49,7 +49,7 @@
   },
   "patch": {
     "tags": [
-      "ReturnReasons"
+      "ReturnReasonsManagement"
     ],
     "security": [
       {
@@ -122,7 +122,7 @@
   },
   "delete": {
     "tags": [
-      "ReturnReasons"
+      "ReturnReasonsManagement"
     ],
     "security": [
       {

--- a/specification/paths/Returns-v1-reasons.json
+++ b/specification/paths/Returns-v1-reasons.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "tags": [
-      "ReturnReasons"
+      "ReturnReasonsManagement"
     ],
     "security": [
       {
@@ -87,7 +87,7 @@
   },
   "post": {
     "tags": [
-      "ReturnReasons"
+      "ReturnReasonsManagement"
     ],
     "security": [
       {

--- a/specification/tags.json
+++ b/specification/tags.json
@@ -143,6 +143,10 @@
     "externalDocs": {}
   },
   {
+    "name": "ReturnReasonsManagement",
+    "externalDocs": {}
+  },
+  {
     "name": "Scopes",
     "externalDocs": {
     }

--- a/src/myparcelcom.js
+++ b/src/myparcelcom.js
@@ -105,6 +105,7 @@
           "Returns",
           "ReturnMethods",
           "ReturnReasons",
+          "ReturnReasonsManagement",
         ]
         for (var i = 0; i < internal.length; i++) {
           var sections = document.querySelectorAll([


### PR DESCRIPTION
As discussed during the demo, we can now hide the return reason management from the rest of the return reason endpoints