### PR TITLE
♻️ ReturnMethod default_weight is not always required

### DIFF
--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -129,9 +129,13 @@
                       },
                       "attributes": {
                         "required": [
-                          "return_type",
-                          "default_weight"
-                        ]
+                          "return_type"
+                        ],
+                        "properties": {
+                          "default_weight": {
+                            "description": "Required if the `return_type` is set to `shipment`."
+                          }
+                        }
                       },
                       "relationships": {
                         "required": [

--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -140,7 +140,15 @@
                       "relationships": {
                         "required": [
                           "shop"
-                        ]
+                        ],
+                        "properties": {
+                          "contract": {
+                            "description": "Required if the `return_type` is set to `shipment`."
+                          },
+                          "service": {
+                            "description": "Required if the `return_type` is set to `shipment`."
+                          }
+                        }
                       }
                     }
                   }

--- a/specification/schemas/ReturnMethodResponse.json
+++ b/specification/schemas/ReturnMethodResponse.json
@@ -14,7 +14,6 @@
         "attributes": {
           "required": [
             "return_type",
-            "default_weight",
             "created_at"
           ]
         },


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-6141
---
- Remove the requirement of `default_weight`.
- Added description to indicate when it is required.