### PR TITLE
MP-6166 Return item reason

### DIFF
--- a/specification/parameters/path-return_reason_id.json
+++ b/specification/parameters/path-return_reason_id.json
@@ -1,7 +1,7 @@
 {
   "name": "return_reason_id",
   "in": "path",
-  "description": "Id of the Return reason.",
+  "description": "Id of the return reason.",
   "required": true,
   "schema": {
     "$ref": "#/components/schemas/Uuid"

--- a/specification/paths/Returns-v1-reasons-return_reason_id.json
+++ b/specification/paths/Returns-v1-reasons-return_reason_id.json
@@ -6,7 +6,7 @@
   ],
   "get": {
     "tags": [
-      "ReturnReasonsManagement"
+      "ReturnReasons"
     ],
     "security": [
       {

--- a/specification/paths/Returns-v1-reasons.json
+++ b/specification/paths/Returns-v1-reasons.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "tags": [
-      "ReturnReasonsManagement"
+      "ReturnReasons"
     ],
     "security": [
       {

--- a/specification/schemas/ReturnItem.json
+++ b/specification/schemas/ReturnItem.json
@@ -65,6 +65,20 @@
         "$ref": "#/components/schemas/ItemFeature"
       },
       "description": "List of features of this item, such as the color or size."
+    },
+    "reason": {
+      "type": "object",
+      "description": "Reason for returning the item. Required if the shop has any <a href=\"/#tag/ReturnReasons/paths/~1returns~1v1~1shops~1%7Bshop_id%7D~1reasons/post\">return reasons set up</a>.",
+      "required": [
+        "code"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "example": "item-damaged",
+          "description": "A code that identifies the reason for the return of this item. See the <a href=\"/#tag/ReturnReasons/paths/~1returns~1v1~1reasons/get\">return-reason</a> `code` attribute."
+        }
+      }
     }
   }
 }

--- a/specification/schemas/ReturnReason.json
+++ b/specification/schemas/ReturnReason.json
@@ -11,6 +11,7 @@
           "properties": {
             "code": {
               "type": "string",
+              "example": "wrong-item",
               "description": "A unique code for the return reason."
             },
             "description": {


### PR DESCRIPTION
## Changes
- 🚚 Moved GET return reason endpoints under ReturnReasons tag instead of ReturnReasonManagement.
- ✨ Added `reason` property to ReturnItem schema.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-6166
- https://myparcelcombv.atlassian.net/browse/MP-6140