### PR TITLE
:sparkles: New endpoint for manual retry of return shipment registrations

### DIFF
--- a/specification/paths.json
+++ b/specification/paths.json
@@ -200,6 +200,9 @@
   "/returns/v1/returns/{return_id}/request-payment": {
     "$ref": "./paths/Returns-v1-returns-return_id-request-payment.json"
   },
+  "/returns/v1/returns/{return_id}/retry-shipment": {
+    "$ref": "./paths/Returns-v1-returns-return_id-retry-shipment.json"
+  },
   "/returns/v1/return-methods": {
     "$ref": "./paths/Returns-v1-return-methods.json"
   },

--- a/specification/paths/Returns-v1-returns-return_id-retry-shipment.json
+++ b/specification/paths/Returns-v1-returns-return_id-retry-shipment.json
@@ -1,0 +1,35 @@
+{
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-return_id"
+    }
+  ],
+  "post": {
+    "tags": [
+      "Returns"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "returns.manage"
+        ]
+      }
+    ],
+    "summary": "Retry shipment registration on a return.",
+    "description": "This endpoint allows the API user to manually trigger shipment registration on a return.",
+    "responses": {
+      "204": {
+        "description": "Shipment registration is successful"
+      },
+      "404": {
+        "description": "No return was found for the given ID."
+      },
+      "422": {
+        "description": "Cannot attempt shipment registration on a return that is not approved."
+      },
+      "500": {
+        "description": "Shipment registration failed"
+      }
+    }
+  }
+}

--- a/specification/schemas/ReturnResponse.json
+++ b/specification/schemas/ReturnResponse.json
@@ -17,7 +17,51 @@
             "consumer_address",
             "items",
             "created_at"
-          ]
+          ],
+          "properties": {
+            "shipment_registrations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "invocation",
+                  "status",
+                  "created_at"
+                ],
+                "properties": {
+                  "invocation": {
+                    "type": "string",
+                    "format": "enum",
+                    "enum": [
+                      "manual",
+                      "automatic"
+                    ],
+                    "description": "The way the shipment registration was invoked",
+                    "example": "automatic"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "success",
+                      "failed"
+                    ],
+                    "example": "success"
+                  },
+                  "error": {
+                    "type": "string",
+                    "example": "Carrier API failure",
+                    "description": "Shipment registration failure error message (when applicable)"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2019-01-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          }
         },
         "relationships": {
           "required": [


### PR DESCRIPTION
# Changes
- Introduced `POST /returns/v1/returns/{return_id}/retry-shipment`
- Added `shipment_registrations` array in Return responses