### PR TITLE
:sparkles: MP-6172 Added locale attribute to Shop schema.

### DIFF
--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -275,6 +275,9 @@
   "LiabilityCoveragesRelationship": {
     "$ref": "./schemas/LiabilityCoveragesRelationship.json"
   },
+  "Locale": {
+    "$ref": "./schemas/Locale.json"
+  },
   "Manifest": {
     "$ref": "./schemas/Manifest.json"
   },

--- a/specification/schemas/Locale.json
+++ b/specification/schemas/Locale.json
@@ -1,0 +1,10 @@
+{
+  "type": "string",
+  "enum": [
+    "de-DE",
+    "en-GB",
+    "it-IT",
+    "nl-NL"
+  ],
+  "example": "en-GB"
+}

--- a/specification/schemas/Shop.json
+++ b/specification/schemas/Shop.json
@@ -50,6 +50,20 @@
               "example": "7467",
               "description": "Any reference to identify the shop."
             },
+            "locale": {
+              "type": [
+                "string"
+              ],
+              "enum": [
+                "en_GB",
+                "nl_NL",
+                "it_IT",
+                "de_DE"
+              ],
+              "default": "en_GB",
+              "example": "nl_NL",
+              "description": "The default language that is used for emails and webpages for this shop."
+            },
             "mollie_connected": {
               "type": "boolean",
               "example": false,

--- a/specification/schemas/Shop.json
+++ b/specification/schemas/Shop.json
@@ -51,18 +51,16 @@
               "description": "Any reference to identify the shop."
             },
             "locale": {
-              "type": [
-                "string"
-              ],
-              "enum": [
-                "en_GB",
-                "nl_NL",
-                "it_IT",
-                "de_DE"
-              ],
-              "default": "en_GB",
-              "example": "nl_NL",
-              "description": "The default language that is used for emails and webpages for this shop."
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Locale"
+                },
+                {
+                  "default": "en-GB",
+                  "example": "nl-NL",
+                  "description": "The default language that is used for emails and webpages for this shop."
+                }
+              ]
             },
             "mollie_connected": {
               "type": "boolean",

--- a/specification/schemas/ShopResponse.json
+++ b/specification/schemas/ShopResponse.json
@@ -16,7 +16,8 @@
             "name",
             "return_address",
             "sender_address",
-            "created_at"
+            "created_at",
+            "locale"
           ],
           "properties": {
             "return_address": {

--- a/specification/schemas/User.json
+++ b/specification/schemas/User.json
@@ -40,14 +40,7 @@
               "example": "+31 234 567 890"
             },
             "locale": {
-              "type": "string",
-              "enum": [
-                "de-DE",
-                "en-GB",
-                "it-IT",
-                "nl-NL"
-              ],
-              "example": "en-GB"
+              "$ref": "/components/schemas/Locale"
             },
             "status": {
               "type": "string",

--- a/specification/schemas/User.json
+++ b/specification/schemas/User.json
@@ -40,7 +40,7 @@
               "example": "+31 234 567 890"
             },
             "locale": {
-              "$ref": "/components/schemas/Locale"
+              "$ref": "#/components/schemas/Locale"
             },
             "status": {
               "type": "string",


### PR DESCRIPTION
## Changes
- ✨  Added `locale` attribute to the Shop schema.
  - Made required only for ShopResponses as it will default to `en_GB`.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-6233

## TODO
- [x] Wait with this merge until the [API PR](https://github.com/MyParcelCOM/api/pull/3049) is created and approved.