### PR TITLE
:sparkles: Added service_options relationship to return methods.

### DIFF
--- a/specification/paths/Returns-v1-return-methods-return_method_id.json
+++ b/specification/paths/Returns-v1-return-methods-return_method_id.json
@@ -21,7 +21,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`shop`</li><li>`service`</li><li>`contract`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`shop`</li><li>`service`</li><li>`service_options`</li><li>`contract`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -22,7 +22,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`shop`</li><li>`service`</li><li>`contract`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`shop`</li><li>`service`</li><li>`service_options`</li><li>`contract`</li></ul>",
         "schema": {
           "type": "string"
         }
@@ -141,9 +141,6 @@
                         }
                       },
                       "relationships": {
-                        "required": [
-                          "shop"
-                        ],
                         "properties": {
                           "contract": {
                             "description": "Required if the `return_type` is set to `shipment`."

--- a/specification/schemas/ReturnMethod.json
+++ b/specification/schemas/ReturnMethod.json
@@ -30,6 +30,9 @@
         },
         "relationships": {
           "type": "object",
+          "required": [
+            "shop"
+          ],
           "additionalProperties": false,
           "properties": {
             "contract": {
@@ -37,6 +40,9 @@
             },
             "service": {
               "$ref": "#/components/schemas/ServiceRelationship"
+            },
+            "service_options": {
+              "$ref": "#/components/schemas/ServiceOptionsRelationship"
             },
             "shop": {
               "$ref": "#/components/schemas/ShopRelationship"

--- a/specification/schemas/ReturnMethodResponse.json
+++ b/specification/schemas/ReturnMethodResponse.json
@@ -17,11 +17,6 @@
             "created_at"
           ]
         },
-        "relationships": {
-          "required": [
-            "shop"
-          ]
-        },
         "links": {
           "readOnly": true,
           "type": "object",


### PR DESCRIPTION
## Changes
- ✨ Added optional `service_options` relationship to `ReturnMethod` schema.
- ✨ Added `service_options` as option to include on GET endpoints for return methods.
- 🚚 Moved making `shop` relationship required to `ReturnMethod` schema instead of in `ReturnMethodResponse` and the POST `ReturnMethod` endpoint, since it is always required.