### PR TITLE
:memo: Hook trigger resource type filter

### DIFF
--- a/specification/paths/Hooks.json
+++ b/specification/paths/Hooks.json
@@ -46,6 +46,19 @@
             "import"
           ]
         }
+      },
+      {
+        "name": "filter[trigger][resource_type]",
+        "in": "query",
+        "description": "[Resource type](https://docs.myparcel.com/api/resources/hooks/trigger.html) to filter the hooks by.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "shipments",
+            "shipment-statuses",
+            "returns"
+          ]
+        }
       }
     ],
     "responses": {


### PR DESCRIPTION
## Changes
- 📝 Added `filter[trigger][resource_type]` query parameter to the `/hooks` endpoint.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-5775