### PR TITLE
✨ Required properties in return analytics approved endpoint

### DIFF
--- a/specification/schemas/returns/ReturnAnalytics.json
+++ b/specification/schemas/returns/ReturnAnalytics.json
@@ -1,6 +1,11 @@
 {
   "type": "object",
   "additionalProperties": false,
+  "required": [
+    "unit_type",
+    "labels",
+    "datasets"
+  ],
   "properties": {
     "unit_type": {
       "type": "string",

--- a/specification/schemas/returns/ReturnAnalytics.json
+++ b/specification/schemas/returns/ReturnAnalytics.json
@@ -26,6 +26,10 @@
       "type": "array",
       "items": {
         "type": "object",
+        "required": [
+          "label",
+          "data"
+        ],
         "properties": {
           "label": {
             "type": "string",


### PR DESCRIPTION
## Changes
- Made the `unit_type`, `labels` and `datasets` properties in `returns/v1/analytics/approved` endpoint response body required.