### PR TITLE
⚡  Added shipment metadata for ReturnSimpleResponse

### DIFF
--- a/specification/paths/Returns-v1-returns.json
+++ b/specification/paths/Returns-v1-returns.json
@@ -16,7 +16,7 @@
       {
         "name": "include",
         "in": "query",
-        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`return_method`</li><li>`shipment`</li><li>`shop`</li><li>`status`</li></ul>",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`return_method`</li><li>`shop`</li><li>`status`</li></ul>",
         "schema": {
           "type": "string"
         }

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -569,6 +569,9 @@
   "Status": {
     "$ref": "./schemas/statuses/Status.json"
   },
+  "StatusLevel": {
+    "$ref": "./schemas/statuses/StatusLevel.json"
+  },
   "StatusRelationship": {
     "$ref": "./schemas/statuses/StatusRelationship.json"
   },

--- a/specification/schemas/returns/ReturnSimpleResponse.json
+++ b/specification/schemas/returns/ReturnSimpleResponse.json
@@ -57,7 +57,6 @@
               "type": "object",
               "additionalProperties": false,
               "required": [
-                "tracking_code",
                 "status"
               ],
               "properties": {

--- a/specification/schemas/returns/ReturnSimpleResponse.json
+++ b/specification/schemas/returns/ReturnSimpleResponse.json
@@ -54,9 +54,7 @@
           "additionalProperties": false,
           "properties": {
             "shipment_tracking_code": {
-              "type": "string",
-              "description": "Tracking code of the shipment",
-              "example": "3SABCD0123456789"
+              "$ref": "#/components/schemas/TrackingCode"
             },
             "shipment_status_code": {
               "type": "string",

--- a/specification/schemas/returns/ReturnSimpleResponse.json
+++ b/specification/schemas/returns/ReturnSimpleResponse.json
@@ -53,47 +53,39 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "shipment": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "status"
+            "shipment_tracking_code": {
+              "type": "string",
+              "description": "Tracking code of the shipment",
+              "example": "3SABCD0123456789"
+            },
+            "shipment_status_code": {
+              "type": "string",
+              "enum": [
+                "shipment-at-parcel-shop",
+                "shipment-at-sorting",
+                "shipment-concept",
+                "shipment-created-without-label",
+                "shipment-created-without-tracking",
+                "shipment-delivered",
+                "shipment-failed",
+                "shipment-on-the-way-to-hub",
+                "shipment-processing",
+                "shipment-received-by-carrier",
+                "shipment-registered",
+                "shipment-registration-failed",
+                "shipment-returned-to-sender",
+                "shipment-voided",
+                "shipment-with-courier"
               ],
-              "properties": {
-                "tracking_code": {
-                  "type": "string",
-                  "description": "Tracking code of the shipment",
-                  "example": "3SDFGDFGDFGDFG"
-                },
-                "status": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "enum": [
-                        "shipment-at-parcel-shop",
-                        "shipment-at-sorting",
-                        "shipment-concept",
-                        "shipment-created-without-label",
-                        "shipment-created-without-tracking",
-                        "shipment-delivered",
-                        "shipment-failed",
-                        "shipment-on-the-way-to-hub",
-                        "shipment-processing",
-                        "shipment-received-by-carrier",
-                        "shipment-registered",
-                        "shipment-registration-failed",
-                        "shipment-returned-to-sender",
-                        "shipment-voided",
-                        "shipment-with-courier"
-                      ],
-                      "description": "Status code of the shipment",
-                      "example": "shipment-registered"
-                    }
-                  }
-                }
-              }
+              "description": "Status code of the shipment",
+              "example": "shipment-registered"
+            },
+            "shipment_status_level": {
+              "$ref": "#/components/schemas/StatusLevel"
+            },
+            "shipment_status_name": {
+              "type": "string",
+              "example": "Delivered"
             }
           }
         }

--- a/specification/schemas/returns/ReturnSimpleResponse.json
+++ b/specification/schemas/returns/ReturnSimpleResponse.json
@@ -47,6 +47,56 @@
               "example": "$API_HOST/returns/v1/returns/8ddfb83f-d600-49c7-b10e-66dd4dc7686a"
             }
           }
+        },
+        "meta": {
+          "readOnly": true,
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "shipment": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "tracking_code",
+                "status"
+              ],
+              "properties": {
+                "tracking_code": {
+                  "type": "string",
+                  "description": "Tracking code of the shipment",
+                  "example": "3SDFGDFGDFGDFG"
+                },
+                "status": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "shipment-at-parcel-shop",
+                        "shipment-at-sorting",
+                        "shipment-concept",
+                        "shipment-created-without-label",
+                        "shipment-created-without-tracking",
+                        "shipment-delivered",
+                        "shipment-failed",
+                        "shipment-on-the-way-to-hub",
+                        "shipment-processing",
+                        "shipment-received-by-carrier",
+                        "shipment-registered",
+                        "shipment-registration-failed",
+                        "shipment-returned-to-sender",
+                        "shipment-voided",
+                        "shipment-with-courier"
+                      ],
+                      "description": "Status code of the shipment",
+                      "example": "shipment-registered"
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/specification/schemas/statuses/Status.json
+++ b/specification/schemas/statuses/Status.json
@@ -62,15 +62,7 @@
               "description": "Resource type this status can be applied to."
             },
             "level": {
-              "type": "string",
-              "enum": [
-                "cancelled",
-                "failed",
-                "in-progress",
-                "pending",
-                "success"
-              ],
-              "example": "success"
+              "$ref": "#/components/schemas/StatusLevel"
             },
             "name": {
               "type": "string",

--- a/specification/schemas/statuses/StatusLevel.json
+++ b/specification/schemas/statuses/StatusLevel.json
@@ -1,0 +1,11 @@
+{
+  "type": "string",
+  "enum": [
+    "cancelled",
+    "failed",
+    "in-progress",
+    "pending",
+    "success"
+  ],
+  "example": "success"
+}


### PR DESCRIPTION
# What's new?
When getting multiple returns, a meta field is added for each which contains the shipment (if any) tracking code and status code.

Removed the shipment include when getting multiple returns.