### PR TITLE
♿️ Explain landed cost shipping_value

### DIFF
--- a/specification/paths/CalculateLandedCosts.json
+++ b/specification/paths/CalculateLandedCosts.json
@@ -54,7 +54,14 @@
                     "description": "Weight in grams."
                   },
                   "shipping_value": {
-                    "$ref": "#/components/schemas/Price"
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Price"
+                      },
+                      {
+                        "description": "The `total_tax` and `total_duty` are calculated from all `items` passed. This `shipping_value` is for any value that is not covered by the items, such as the packaging or postage fees."
+                      }
+                    ]
                   },
                   "items": {
                     "type": "array",


### PR DESCRIPTION
Added because someone was passing a big number as `shipping_value`, probably confusing it with "shipment value".