### PR TITLE
:sparkles: add shipping_and_return and label_in_the_box meta properties to OrderResponse

### DIFF
--- a/specification/schemas/return-orders/OrderResponse.json
+++ b/specification/schemas/return-orders/OrderResponse.json
@@ -44,6 +44,18 @@
           "required": [
             "shop"
           ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "shipping_and_return": {
+              "type": "boolean"
+            },
+            "label_in_the_box": {
+              "type": "boolean"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
**Related issue**
https://myparcelcombv.atlassian.net/browse/MP-6420