### PR TITLE
♿️ Show includes in the shipment-status response examples

### DIFF
--- a/specification/paths/Shipments-shipment_id-Statuses-shipment_status_id.json
+++ b/specification/paths/Shipments-shipment_id-Statuses-shipment_status_id.json
@@ -53,6 +53,9 @@
               "properties": {
                 "data": {
                   "$ref": "#/components/schemas/ShipmentStatusResponse"
+                },
+                "included": {
+                  "$ref": "#/components/schemas/ShipmentStatusIncludes"
                 }
               }
             }

--- a/specification/paths/Shipments-shipment_id-Statuses.json
+++ b/specification/paths/Shipments-shipment_id-Statuses.json
@@ -59,6 +59,9 @@
                 "meta": {
                   "$ref": "#/components/schemas/PaginationMeta"
                 },
+                "included": {
+                  "$ref": "#/components/schemas/ShipmentStatusIncludes"
+                },
                 "links": {
                   "type": "object",
                   "required": [

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -530,6 +530,9 @@
   "ShipmentStatus": {
     "$ref": "./schemas/shipment-statuses/ShipmentStatus.json"
   },
+  "ShipmentStatusIncludes": {
+    "$ref": "./schemas/shipment-statuses/ShipmentStatusIncludes.json"
+  },
   "ShipmentStatusRelationship": {
     "$ref": "./schemas/shipment-statuses/ShipmentStatusRelationship.json"
   },

--- a/specification/schemas/shipment-statuses/ShipmentStatus.json
+++ b/specification/schemas/shipment-statuses/ShipmentStatus.json
@@ -32,11 +32,11 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "status": {
-              "$ref": "#/components/schemas/StatusRelationship"
-            },
             "shipment": {
               "$ref": "#/components/schemas/ShipmentRelationship"
+            },
+            "status": {
+              "$ref": "#/components/schemas/StatusRelationship"
             }
           }
         }

--- a/specification/schemas/shipment-statuses/ShipmentStatusIncludes.json
+++ b/specification/schemas/shipment-statuses/ShipmentStatusIncludes.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "items": {
+    "anyOf": [
+      {
+        "$ref": "#/components/schemas/ShipmentResponse"
+      },
+      {
+        "$ref": "#/components/schemas/StatusResponse"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This will make it more clear when we tell users:
"the webhook payload is similar to the shipment-status response with includes"