### PR TITLE
MP-6479 :sparkles: Added properties to hide product card details to Shop schema

### DIFF
--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -80,11 +80,11 @@
                       "example": "#fdb915",
                       "description": "RGB color code in #-hexadecimal notation."
                     },
-                    "hide_product_details": {
+                    "hide_product_features": {
                       "type": "boolean",
                       "example": false,
                       "default": false,
-                      "description": "Whether to hide the details of an order's products on the return portal."
+                      "description": "Whether to hide the features of an order's products on the return portal."
                     },
                     "hide_product_description": {
                       "type": "boolean",

--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -79,6 +79,24 @@
                       "maxLength": 7,
                       "example": "#fdb915",
                       "description": "RGB color code in #-hexadecimal notation."
+                    },
+                    "hide_product_details": {
+                      "type": "boolean",
+                      "example": false,
+                      "default": false,
+                      "description": "Whether to hide the details of an order's products on the return portal."
+                    },
+                    "hide_product_description": {
+                      "type": "boolean",
+                      "example": false,
+                      "default": false,
+                      "description": "Whether to hide the description of an order's products on the return portal."
+                    },
+                    "hide_product_price": {
+                      "type": "boolean",
+                      "example": false,
+                      "default": false,
+                      "description": "Whether to hide the price of an order's products on the return portal."
                     }
                   },
                   "description": "Custom branding for your MyParcel.com return portal."


### PR DESCRIPTION
## Changes
- Added three properties to hide order product details on the return portal:
  - `hide_product_features`
  - `hide_product_description`
  - `hide_product_price`

## Related issues
- https://myparcelcombv.atlassian.net/browse/MP-6479
- https://myparcelcombv.atlassian.net/browse/MP-6462