### PR TITLE
🔗 Move unicode link icons to CSS

### DIFF
--- a/root.json
+++ b/root.json
@@ -21,7 +21,7 @@
     "securitySchemes": {
       "OAuth2": {
         "type": "oauth2",
-        "description": "[\uD83D\uDD17 API documentation](https://docs.myparcel.com/api/authentication.html)",
+        "description": "[API documentation](https://docs.myparcel.com/api/authentication.html)",
         "name": "Authorization",
         "in": "header",
         "scheme": "Bearer",

--- a/specification/tags.json
+++ b/specification/tags.json
@@ -13,7 +13,7 @@
     "name": "Carriers",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/carriers.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -45,7 +45,7 @@
     "name": "Contracts",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/contracts.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -57,21 +57,21 @@
     "name": "Files",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/files.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "Hooks",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/hooks.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "HookLogs",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/hooks/logs.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -88,7 +88,7 @@
     "name": "LiabilityCoverages",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/liability-coverages.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -125,14 +125,14 @@
     "name": "Regions",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/regions.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "Reports",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/reports.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -164,28 +164,28 @@
     "name": "Services",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/services.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "ServiceOptions",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/service-options.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "ServiceRates",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/service-rates.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "Shipments",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/shipments.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -197,14 +197,14 @@
     "name": "Shops",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/shops.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
     "name": "Statuses",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/resources/statuses.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {
@@ -226,7 +226,7 @@
     "name": "RPC",
     "externalDocs": {
       "url": "https://docs.myparcel.com/api/rpc-endpoints.html",
-      "description": "\uD83D\uDD17 API documentation"
+      "description": "API documentation"
     }
   },
   {

--- a/src/myparcelcom.css
+++ b/src/myparcelcom.css
@@ -3,6 +3,10 @@ body {
   padding: 0;
 }
 
+a[href^="https://docs.myparcel.com"]:before {
+  content: "🔗 ";
+}
+
 img[alt=logo] {
   width: 200px;
 }


### PR DESCRIPTION
The unicode characters in our specification make the JSON to YAML parser throw up.