### PR TITLE
:lady_beetle: Correct post invitation scope

### DIFF
--- a/specification/paths/Onboarding-v1-invitations.json
+++ b/specification/paths/Onboarding-v1-invitations.json
@@ -100,7 +100,7 @@
     "security": [
       {
         "OAuth2": [
-          "invitations.manage"
+          "brokers.manage"
         ]
       }
     ],


### PR DESCRIPTION
## Changes
- 🐞 Corrected the required scope for posting an invitation to `brokers.manage`. It was listed as `invitations.manage`, but that scope doesn't exist and the API endpoint is actually protected by `brokers.manage`.