### PR TITLE
:no_mouth: Allow null values for invitation first name and last name.

### DIFF
--- a/specification/schemas/invitations/InvitationRequest.json
+++ b/specification/schemas/invitations/InvitationRequest.json
@@ -20,11 +20,17 @@
           ],
           "properties": {
             "first_name": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "example": "Sherlock"
             },
             "last_name": {
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "example": "Holmes"
             },
             "email": {


### PR DESCRIPTION
The back office inputs will go back to empty strings when they held a value that is removed. 
Our back office logic also converts empty strings to `null` when posting to the API.
The API specification did not allow `null` values, only strings. I think this is too strict, as in the end it makes no difference to leave out the value or send `null` (in a POST request, PATCH is a different story).

## Changes
- 😶 Allow `null` value for invitation first and last names.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-6567