### PR TITLE
:unlock: Optional boolean properties in branding objects.

### DIFF
--- a/specification/schemas/shops/ShopResponse.json
+++ b/specification/schemas/shops/ShopResponse.json
@@ -33,23 +33,6 @@
                 "city",
                 "country_code"
               ]
-            },
-            "branding": {
-              "properties": {
-                "returns": {
-                  "required": [
-                    "hide_product_features",
-                    "hide_product_description",
-                    "hide_product_price"
-                  ]
-                },
-                "tracking": {
-                  "required": [
-                    "hide_customer_reference",
-                    "hide_sender_address"
-                  ]
-                }
-              }
             }
           }
         },


### PR DESCRIPTION
It seems that the parent objects can hold values without the boolean properties being returned by our API.
Such is the case when for example only posting a logo and not any styling properties. 
Therefore, the boolean properties are not always present in the response when the parent is present, and the properties should not be required.

## Changes
- 🔓  Made the boolean properties of the branding objects optional.
