### PR TITLE
✨ Introduce broker filters on endpoints for shipments and reports

### DIFF
--- a/specification/paths/Organizations.json
+++ b/specification/paths/Organizations.json
@@ -30,6 +30,9 @@
       },
       {
         "$ref": "#/components/parameters/query-filter-search-name"
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-broker"
       }
     ],
     "responses": {

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -66,6 +66,9 @@
         "$ref": "#/components/parameters/query-filter-organization"
       },
       {
+        "$ref": "#/components/parameters/query-filter-broker"
+      },
+      {
         "$ref": "#/components/parameters/query-filter-carrier"
       },
       {

--- a/specification/paths/Shops.json
+++ b/specification/paths/Shops.json
@@ -44,6 +44,9 @@
         "$ref": "#/components/parameters/query-filter-search-name"
       },
       {
+        "$ref": "#/components/parameters/query-filter-broker"
+      },
+      {
         "$ref": "#/components/parameters/query-filter-organization"
       },
       {

--- a/specification/schemas/reports/Report.json
+++ b/specification/schemas/reports/Report.json
@@ -108,6 +108,16 @@
                     "example": "9cdf86e8-333f-4ed9-bb31-4935c780c947"
                   }
                 },
+                "brokers": {
+                  "type": "array",
+                  "description": "Array of broker IDs to filter included shipments by.",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$",
+                    "example": "a294ee55-bc94-4890-b734-afd56c158f95"
+                  }
+                },
                 "carriers": {
                   "type": "array",
                   "description": "Array of carrier IDs to filter included shipments by.",


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-3738
---
To be able to filter the shipment overview and the reports on the broker(s) that are selected (for multi-broker admins).

Meanwhile we also need to be able to limit the organization + shop filters to these broker for the values to make sense.

**Question**
Currently the carriers / contracts / services endpoints are internally filtered on all brokers the user + client have access to.
I guess we should also allow a `filter[broker]` to be passed via the URL so these values can be limited to just 1 broker?