### PR TITLE
:sparkles: Manage demo orders specification

### DIFF
--- a/specification/parameters.json
+++ b/specification/parameters.json
@@ -38,6 +38,9 @@
   "path-country_code": {
     "$ref": "./parameters/path-country_code.json"
   },
+  "path-demo_order_id": {
+    "$ref": "./parameters/path-demo_order_id.json"
+  },
   "path-enterprise_id": {
     "$ref": "./parameters/path-enterprise_id.json"
   },

--- a/specification/parameters/path-demo_order_id.json
+++ b/specification/parameters/path-demo_order_id.json
@@ -1,0 +1,9 @@
+{
+  "name": "demo_order_id",
+  "in": "path",
+  "description": "Id of the demo order.",
+  "required": true,
+  "schema": {
+    "$ref": "#/components/schemas/Uuid"
+  }
+}

--- a/specification/paths.json
+++ b/specification/paths.json
@@ -203,6 +203,12 @@
   "/reports/{report_id}/files/{file_id}": {
     "$ref": "./paths/Reports-report_id-Files-file_id.json"
   },
+  "/returns/v1/demo-orders": {
+    "$ref": "./paths/Returns-v1-demo-orders.json"
+  },
+  "/returns/v1/demo-orders/{demo_order_id}": {
+    "$ref": "./paths/Returns-v1-demo-orders-demo_order_id.json"
+  },
   "/returns/v1/returns": {
     "$ref": "./paths/Returns-v1-returns.json"
   },

--- a/specification/paths/Returns-v1-demo-orders-demo_order_id.json
+++ b/specification/paths/Returns-v1-demo-orders-demo_order_id.json
@@ -1,0 +1,58 @@
+{
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/path-demo_order_id"
+    }
+  ],
+  "get": {
+    "tags": [
+      "Returns"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "returns.manage"
+        ]
+      }
+    ],
+    "summary": "Get a demo order resource.",
+    "description": "This endpoint retrieves a demo order resource by the specified ID.",
+    "parameters": [
+      {
+        "name": "include",
+        "in": "query",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br> The relationships that can be included are:<ul><li>`shop`</li></ul>",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Retrieved the demo order.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/components/schemas/DemoOrderResponse"
+                },
+                "included": {
+                  "$ref": "#/components/schemas/ShopResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "No demo order was found for the given ID."
+      }
+    }
+  }
+}

--- a/specification/paths/Returns-v1-demo-orders.json
+++ b/specification/paths/Returns-v1-demo-orders.json
@@ -34,7 +34,6 @@
               "type": "object",
               "required": [
                 "data",
-                "meta",
                 "links"
               ],
               "properties": {

--- a/specification/paths/Returns-v1-demo-orders.json
+++ b/specification/paths/Returns-v1-demo-orders.json
@@ -1,0 +1,195 @@
+{
+  "get": {
+    "tags": [
+      "Returns"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "returns.manage"
+        ]
+      }
+    ],
+    "summary": "Get all demo orders resources.",
+    "description": "This endpoint retrieves generated orders to test creating returns.",
+    "parameters": [
+      {
+        "$ref": "#/components/parameters/query-filter-shop"
+      },
+      {
+        "name": "include",
+        "in": "query",
+        "description": "Comma separated string of the relationship names you want to include the data of.<br> The relationships that can be included are:<ul><li>`shop`</li></ul>",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Retrieved the demo orders.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data",
+                "meta",
+                "links"
+              ],
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DemoOrderResponse"
+                  }
+                },
+                "meta": {
+                  "$ref": "#/components/schemas/PaginationMeta"
+                },
+                "included": {
+                  "$ref": "#/components/schemas/ShopResponse"
+                },
+                "links": {
+                  "type": "object",
+                  "required": [
+                    "self",
+                    "first",
+                    "last"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "self": {
+                      "type": "string",
+                      "example": "$API_HOST/returns/v1/demo-orders?page[number]=3&page[size]=30"
+                    },
+                    "first": {
+                      "type": "string",
+                      "example": "$API_HOST/returns/v1/demo-orders?page[number]=1&page[size]=30"
+                    },
+                    "prev": {
+                      "type": "string",
+                      "example": "$API_HOST/returns/v1/demo-orders?page[number]=2&page[size]=30"
+                    },
+                    "next": {
+                      "type": "string",
+                      "example": "$API_HOST/returns/v1/demo-orders?page[number]=4&page[size]=30"
+                    },
+                    "last": {
+                      "type": "string",
+                      "example": "$API_HOST/returns/v1/demo-orders?page[number]=13&page[size]=30"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "post": {
+    "tags": [
+      "Returns"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "returns.manage"
+        ]
+      }
+    ],
+    "summary": "Create a new demo order.",
+    "description": "This endpoint creates a new demo order with the posted data.",
+    "requestBody": {
+      "description": "The demo order object to be created.",
+      "required": true,
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemoOrder"
+                  },
+                  {
+                    "required": [
+                      "attributes",
+                      "relationships"
+                    ],
+                    "properties": {
+                      "id": {
+                        "readOnly": true
+                      },
+                      "attributes": {
+                        "required": [
+                          "items",
+                          "recipient_address"
+                        ],
+                        "properties": {
+                          "recipient_address": {
+                            "required": [
+                              "first_name",
+                              "last_name",
+                              "street_1",
+                              "city",
+                              "country_code",
+                              "email"
+                            ]
+                          },
+                          "items": {
+                            "items": {
+                              "required": [
+                                "id",
+                                "name",
+                                "description",
+                                "quantity",
+                                "item_price"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "required": [
+                          "shop"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "201": {
+        "description": "The demo order has been created.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "data": {
+                  "$ref": "#/components/schemas/DemoOrderResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -152,6 +152,12 @@
   "DocumentType": {
     "$ref": "./schemas/files/DocumentType.json"
   },
+  "DemoOrder": {
+    "$ref": "./schemas/return-orders/DemoOrder.json"
+  },
+  "DemoOrderResponse": {
+    "$ref": "./schemas/return-orders/DemoOrderResponse.json"
+  },
   "Email": {
     "$ref": "./schemas/addresses/Email.json"
   },

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -155,6 +155,9 @@
   "DemoOrder": {
     "$ref": "./schemas/return-orders/DemoOrder.json"
   },
+  "DemoOrderResource": {
+    "$ref": "./schemas/return-orders/DemoOrderResource.json"
+  },
   "DemoOrderResponse": {
     "$ref": "./schemas/return-orders/DemoOrderResponse.json"
   },

--- a/specification/schemas/return-orders/DemoOrder.json
+++ b/specification/schemas/return-orders/DemoOrder.json
@@ -1,0 +1,35 @@
+{
+  "allOf": [
+    {
+      "$ref": "#/components/schemas/Order"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^demo-orders$",
+          "example": "demo-orders"
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "outbound_shipment_identifier": {
+              "$ref": "#/components/schemas/Uuid"
+            },
+            "is_3rd_party": {
+              "type": "boolean",
+              "description": "Indicates whether the demo order should be handled by a third party",
+              "default": false
+            },
+            "recipient_address": {
+              "required": [
+                "email"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/specification/schemas/return-orders/DemoOrder.json
+++ b/specification/schemas/return-orders/DemoOrder.json
@@ -24,7 +24,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/components/schemas/OrderItem"
-              }
+              },
+              "minItems": 1
             },
             "outbound_shipment_identifier": {
               "type": "string",

--- a/specification/schemas/return-orders/DemoOrder.json
+++ b/specification/schemas/return-orders/DemoOrder.json
@@ -5,11 +5,6 @@
     },
     {
       "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^demo-orders$",
-          "example": "demo-orders"
-        },
         "attributes": {
           "type": "object",
           "additionalProperties": false,
@@ -43,6 +38,14 @@
               "type": "boolean",
               "description": "Indicates whether the demo order should be handled by a third party",
               "default": false
+            }
+          }
+        },
+        "relationships": {
+          "type": "object",
+          "properties": {
+            "shop": {
+              "$ref": "#/components/schemas/ShopRelationship"
             }
           }
         }

--- a/specification/schemas/return-orders/DemoOrder.json
+++ b/specification/schemas/return-orders/DemoOrder.json
@@ -28,9 +28,16 @@
               "minItems": 1
             },
             "outbound_shipment_identifier": {
-              "type": "string",
-              "description": "Shipment identifier of the outbound shipment",
-              "example": "93011952"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Shipment identifier of the outbound shipment",
+                  "example": "93011952"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "is_third_party": {
               "type": "boolean",

--- a/specification/schemas/return-orders/DemoOrder.json
+++ b/specification/schemas/return-orders/DemoOrder.json
@@ -1,7 +1,7 @@
 {
   "allOf": [
     {
-      "$ref": "#/components/schemas/Order"
+      "$ref": "#/components/schemas/DemoOrderResource"
     },
     {
       "properties": {
@@ -14,18 +14,27 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "outbound_shipment_identifier": {
-              "$ref": "#/components/schemas/Uuid"
+            "created_at": {
+              "$ref": "#/components/schemas/Timestamp"
             },
-            "is_3rd_party": {
+            "recipient_address": {
+              "$ref": "#/components/schemas/BaseAddress"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OrderItem"
+              }
+            },
+            "outbound_shipment_identifier": {
+              "type": "string",
+              "description": "Shipment identifier of the outbound shipment",
+              "example": "93011952"
+            },
+            "is_third_party": {
               "type": "boolean",
               "description": "Indicates whether the demo order should be handled by a third party",
               "default": false
-            },
-            "recipient_address": {
-              "required": [
-                "email"
-              ]
             }
           }
         }

--- a/specification/schemas/return-orders/DemoOrderResource.json
+++ b/specification/schemas/return-orders/DemoOrderResource.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "pattern": "^demo-orders$",
+      "example": "demo-orders"
+    },
+    "id": {
+      "type": "string",
+      "example": "12345",
+      "description": "The reference by which this demo order can be retrieved from its source."
+    }
+  }
+}

--- a/specification/schemas/return-orders/DemoOrderResponse.json
+++ b/specification/schemas/return-orders/DemoOrderResponse.json
@@ -45,27 +45,6 @@
           "required": [
             "shop"
           ]
-        },
-        "meta": {
-          "type": "object",
-          "additionalProperties": false,
-          "description": "Properties indicating whether the order was sent with a shipping method that supports returning the shipment with a previously provided label",
-          "required": [
-            "shipping_and_return",
-            "label_in_the_box",
-            "package_type"
-          ],
-          "properties": {
-            "shipping_and_return": {
-              "type": "boolean"
-            },
-            "label_in_the_box": {
-              "type": "boolean"
-            },
-            "package_type": {
-              "$ref": "#/components/schemas/PackageType"
-            }
-          }
         }
       }
     }

--- a/specification/schemas/return-orders/DemoOrderResponse.json
+++ b/specification/schemas/return-orders/DemoOrderResponse.json
@@ -1,0 +1,73 @@
+{
+  "allOf": [
+    {
+      "$ref": "#/components/schemas/DemoOrder"
+    },
+    {
+      "required": [
+        "id",
+        "attributes",
+        "relationships",
+        "meta"
+      ],
+      "properties": {
+        "attributes": {
+          "required": [
+            "created_at",
+            "recipient_address",
+            "items"
+          ],
+          "properties": {
+            "recipient_address": {
+              "required": [
+                "first_name",
+                "last_name",
+                "street_1",
+                "city",
+                "country_code",
+                "email"
+              ]
+            },
+            "items": {
+              "items": {
+                "required": [
+                  "id",
+                  "name",
+                  "description",
+                  "quantity",
+                  "item_price"
+                ]
+              }
+            }
+          }
+        },
+        "relationships": {
+          "required": [
+            "shop"
+          ]
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Properties indicating whether the order was sent with a shipping method that supports returning the shipment with a previously provided label",
+          "required": [
+            "shipping_and_return",
+            "label_in_the_box",
+            "package_type"
+          ],
+          "properties": {
+            "shipping_and_return": {
+              "type": "boolean"
+            },
+            "label_in_the_box": {
+              "type": "boolean"
+            },
+            "package_type": {
+              "$ref": "#/components/schemas/PackageType"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/specification/schemas/return-orders/DemoOrderResponse.json
+++ b/specification/schemas/return-orders/DemoOrderResponse.json
@@ -7,8 +7,7 @@
       "required": [
         "id",
         "attributes",
-        "relationships",
-        "meta"
+        "relationships"
       ],
       "properties": {
         "attributes": {


### PR DESCRIPTION
## Changes
- add specification for GET and POST `/returns/v1/demo-orders`
- add specification for GET `/returns/v1/demo-orders/{demo_order_id}`

## Related issue
https://myparcelcombv.atlassian.net/browse/MP-6732