### PR TITLE
🚚 Move volumetric_weight_divisor to services

### DIFF
--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -33,18 +33,18 @@
         "$ref": "#/components/parameters/query-filter-weight"
       },
       {
+        "deprecated": true,
         "name": "filter[volumetric_weight]",
         "in": "query",
         "description": "<strike>Volumetric weight value in grams to filter by. <br>Service rates for services that use volumetric weight will be filtered on the highest value between gross weight and volumetric weight. Use in conjunction with the filter[weight] filter above.</strike> Deprecated in favor of `filter[volume]`",
         "schema": {
           "type": "string"
-        },
-        "deprecated": true
+        }
       },
       {
         "name": "filter[volume]",
         "in": "query",
-        "description": "This filter expects shipment volume in liters (dm3). This is used to calculate the volumetric weight, using the `volumetric_weight_divisor` of each service rate. Service rates are then filtered based on their weight range. It is recommended to use this filter in conjunction with the `filter[weight]` filter to get the most accurate results.",
+        "description": "This filter expects shipment volume in liters (dm3). This is used to calculate the volumetric weight, using the `volumetric_weight_divisor` of the related service. Service rates are then filtered based on their weight range. It is recommended to use this filter in conjunction with the `filter[weight]` filter to get the most accurate results.",
         "schema": {
           "type": "string"
         }

--- a/specification/schemas/service-rates/ServiceRate.json
+++ b/specification/schemas/service-rates/ServiceRate.json
@@ -70,12 +70,6 @@
               "example": 12.5,
               "description": "Volume in liters. (dm3)"
             },
-            "volumetric_weight_divisor": {
-              "type": "number",
-              "example": 4000,
-              "description": "The volumetric weight divisor is used to calculate the volumetric weight of a shipment. Multiplying the length (mm) x width (mm) x height (mm) of a shipment and dividing it by this number will result in the volumetric weight (g). See <a href=\"https://docs.myparcel.com/api/resources/shipments/physical-properties/volumetric-weight.html\"/>the documentation</a> for more information.",
-              "default": 4000
-            },
             "is_dynamic": {
               "type": "boolean",
               "default": false,

--- a/specification/schemas/services/Service.json
+++ b/specification/schemas/services/Service.json
@@ -105,6 +105,11 @@
               "example": true,
               "description": "Whether the volumetric weight of a shipment is taken into account when determining the price for a service."
             },
+            "volumetric_weight_divisor": {
+              "type": "number",
+              "example": 4000,
+              "description": "The volumetric weight divisor is used to calculate the volumetric weight of a shipment. Multiplying the length (mm) x width (mm) x height (mm) of a shipment and dividing it by this number will result in the volumetric weight (g). See <a href=\"https://docs.myparcel.com/api/resources/shipments/physical-properties/volumetric-weight.html\"/>the documentation</a> for more information."
+            },
             "strict_consolidation": {
               "type": "boolean",
               "example": true,

--- a/specification/schemas/shipments/BasePhysicalProperties.json
+++ b/specification/schemas/shipments/BasePhysicalProperties.json
@@ -58,7 +58,7 @@
       "minimum": 1,
       "maximum": 2147483647,
       "example": 4500,
-      "description": "Volumetric weight in grams. Calculated by the API by multiplying shipment dimensions (if present) and dividing them by 4000: (height in mm * length in mm * width in mm) / 4000."
+      "description": "Volumetric weight in grams. Calculated by our API by multiplying shipment dimensions (if present) and dividing them by the volumetric_weight_divisor of the service. See <a href=\"https://docs.myparcel.com/api/resources/shipments/physical-properties/volumetric-weight.html\"/>the documentation</a> for more information."
     }
   }
 }


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-6722
---
- Moved the `volumetric_weight_divisor` attribute from service-rates to services.
  - This is not a breaking change, since it was never implemented in our API
- Updated some descriptions to reflect this change.
  - `filter[volume]` of service-rates
  - `volumetric_weight` of shipments