### PR TITLE
🧹 Cleanup some required and deprecated definitions

### DIFF
--- a/specification/parameters/header-accept-language.json
+++ b/specification/parameters/header-accept-language.json
@@ -13,6 +13,5 @@
     ]
   },
   "description": "Determines the language in which the ``description`` is returned. Value must be <a href=\"https://en.wikipedia.org/wiki/Language_localisation#Language_tags_and_codes\" target=\"_blank\">ISO 3166-1 alpha-2 compliant</a> (for example: ``en-GB``, ``nl-NL``)",
-  "example": "en-GB",
-  "required": false
+  "example": "en-GB"
 }

--- a/specification/paths/Manifests-manifest_id-Files-file_id.json
+++ b/specification/paths/Manifests-manifest_id-Files-file_id.json
@@ -27,9 +27,9 @@
     "description": "This endpoint retrieves a file of the supplied manifest.",
     "parameters": [
       {
+        "deprecated": true,
         "name": "Accept",
         "in": "header",
-        "deprecated": true,
         "description": "You must set the accept header to retrieve the file in the given format. Possible options are: <ul><li>`application/pdf`</li><li>`text/csv`</li></ul>",
         "required": false,
         "schema": {

--- a/specification/paths/Manifests-manifest_id-Files-file_id.json
+++ b/specification/paths/Manifests-manifest_id-Files-file_id.json
@@ -31,7 +31,6 @@
         "name": "Accept",
         "in": "header",
         "description": "You must set the accept header to retrieve the file in the given format. Possible options are: <ul><li>`application/pdf`</li><li>`text/csv`</li></ul>",
-        "required": false,
         "schema": {
           "type": "string",
           "enum": [

--- a/specification/paths/RegisteredShipments.json
+++ b/specification/paths/RegisteredShipments.json
@@ -132,9 +132,9 @@
                     }
                   },
                   "label_mime_type": {
+                    "deprecated": true,
                     "type": "string",
                     "example": "application/pdf",
-                    "deprecated": true,
                     "description": "Deprecated, use `label.mime_type` instead. In case both are used, `label.mime_type` will get priority."
                   },
                   "label": {

--- a/specification/paths/Shipments-shipment_id.json
+++ b/specification/paths/Shipments-shipment_id.json
@@ -110,9 +110,9 @@
                 "type": "object",
                 "properties": {
                   "label_mime_type": {
+                    "deprecated": true,
                     "type": "string",
                     "example": "application/pdf",
-                    "deprecated": true,
                     "description": "Deprecated, use `label.mime_type` instead. In case both are used, `label.mime_type` will get priority."
                   },
                   "label": {

--- a/specification/paths/Shipments.json
+++ b/specification/paths/Shipments.json
@@ -270,9 +270,9 @@
                     "description": "Adds the shipment to the next collection (collection_time.from is closest to now in the future). Does nothing if combined with collection relationship."
                   },
                   "label_mime_type": {
+                    "deprecated": true,
                     "type": "string",
                     "example": "application/pdf",
-                    "deprecated": true,
                     "description": "Deprecated, use `label.mime_type` instead. In case both are used, `label.mime_type` will get priority."
                   },
                   "label": {

--- a/specification/schemas/carriers/Carrier.json
+++ b/specification/schemas/carriers/Carrier.json
@@ -63,8 +63,8 @@
               }
             },
             "label_mime_types": {
-              "type": "array",
               "deprecated": true,
+              "type": "array",
               "items": {
                 "type": "string",
                 "example": "application/pdf"

--- a/specification/schemas/files/CombinedFileResource.json
+++ b/specification/schemas/files/CombinedFileResource.json
@@ -1,6 +1,6 @@
 {
-  "type": "object",
   "deprecated": true,
+  "type": "object",
   "required": [
     "type"
   ],

--- a/specification/schemas/integrations/Integration.json
+++ b/specification/schemas/integrations/Integration.json
@@ -25,10 +25,10 @@
               "description": "A description of what the integration is used for."
             },
             "connect_url": {
+              "deprecated": true,
               "type": "string",
               "example": "https://api.myparcel.com/integrations/marketplace/init-auth",
-              "description": "A link to perform OAuth 2.0 authentication with the integration platform.",
-              "deprecated": true
+              "description": "A link to perform OAuth 2.0 authentication with the integration platform."
             },
             "readme_url": {
               "type": "string",

--- a/specification/schemas/services/ServiceResponse.json
+++ b/specification/schemas/services/ServiceResponse.json
@@ -28,9 +28,7 @@
         },
         "relationships": {
           "required": [
-            "carrier",
-            "region_from",
-            "region_to"
+            "carrier"
           ]
         },
         "links": {

--- a/specification/schemas/shipments/Shipment.json
+++ b/specification/schemas/shipments/Shipment.json
@@ -19,12 +19,12 @@
               }
             },
             "recipient_tax_number": {
+              "deprecated": true,
               "type": [
                 "string",
                 "null"
               ],
-              "description": "Use `recipient_tax_identification_numbers` instead.",
-              "deprecated": true
+              "description": "Use `recipient_tax_identification_numbers` instead."
             },
             "return_address": {
               "$ref": "#/components/schemas/BaseAddress"
@@ -40,12 +40,12 @@
               }
             },
             "sender_tax_number": {
+              "deprecated": true,
               "type": [
                 "string",
                 "null"
               ],
-              "description": "Use `sender_tax_identification_numbers` instead.",
-              "deprecated": true
+              "description": "Use `sender_tax_identification_numbers` instead."
             },
             "pickup_location": {
               "oneOf": [


### PR DESCRIPTION
- Moved `deprecated` definition to top of object structure
- Removed useless (`"required": "false"`) and deprecated required definitions (`region_from` and `region_to`)