### PR TITLE
✏️ Set proper types on query filters

### DIFF
--- a/specification/parameters/query-filter-weight.json
+++ b/specification/parameters/query-filter-weight.json
@@ -3,6 +3,6 @@
   "in": "query",
   "description": "Weight value in grams to filter by.",
   "schema": {
-    "type": "string"
+    "type": "integer"
   }
 }

--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -39,7 +39,7 @@
         "name": "filter[label_in_the_box]",
         "in": "query",
         "description": "When set to true, the endpoint will return only return methods that offer label in the box service. However, in case that there is no label in the box return method available, the endpoint will respond with all return methods, except shipping and return, unless specified as a filter. When set to false, the endpoint will exclude all label in the box return methods.",
-        "schema":  {
+        "schema": {
           "type": "boolean"
         }
       }

--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -38,7 +38,7 @@
         "in": "query",
         "description": "<strike>Volumetric weight value in grams to filter by. <br>Service rates for services that use volumetric weight will be filtered on the highest value between gross weight and volumetric weight. Use in conjunction with the filter[weight] filter above.</strike> Deprecated in favor of `filter[volume]`",
         "schema": {
-          "type": "string"
+          "type": "integer"
         }
       },
       {
@@ -46,7 +46,7 @@
         "in": "query",
         "description": "This filter expects shipment volume in liters (dm3). This is used to calculate the volumetric weight, using the `volumetric_weight_divisor` of the related service. Service rates are then filtered based on their weight range. It is recommended to use this filter in conjunction with the `filter[weight]` filter to get the most accurate results.",
         "schema": {
-          "type": "string"
+          "type": "number"
         }
       },
       {


### PR DESCRIPTION
Since the shipment `weight` is an integer, the `filter[weight]` and `filter[volumetric_weight]` should reflect this too.
Same goes for the shipment `volume` and `filter[volume]`.