### PR TITLE
:sparkles: MP-6785 Added includes_vat to service rate attributes.

### DIFF
--- a/specification/schemas/service-rates/ServiceRate.json
+++ b/specification/schemas/service-rates/ServiceRate.json
@@ -96,6 +96,11 @@
             },
             "oversize_purchase_price": {
               "$ref": "#/components/schemas/Price"
+            },
+            "includes_vat": {
+              "type": "boolean",
+              "default": "false",
+              "description": "Indicates whether VAT is included in the price returned by the API."
             }
           }
         },

--- a/specification/schemas/service-rates/ServiceRateResponse.json
+++ b/specification/schemas/service-rates/ServiceRateResponse.json
@@ -14,7 +14,9 @@
         "attributes": {
           "required": [
             "weight_min",
-            "weight_max"
+            "weight_max",
+            "is_dynamic",
+            "includes_vat"
           ]
         },
         "relationships": {


### PR DESCRIPTION
## Changes
- Added `includes_vat` attribute to ServiceRate schema.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-6785