### PR TITLE
✨ Add volumetric_weight_divisor_factor to Contract resource

### DIFF
--- a/specification/paths/ServiceRates.json
+++ b/specification/paths/ServiceRates.json
@@ -46,7 +46,8 @@
         "in": "query",
         "description": "This filter expects shipment volume in liters (dm3). This is used to calculate the volumetric weight, using the `volumetric_weight_divisor` of the related service. Service rates are then filtered based on their weight range. It is recommended to use this filter in conjunction with the `filter[weight]` filter to get the most accurate results.",
         "schema": {
-          "type": "number"
+          "type": "number",
+          "format": "float"
         }
       },
       {

--- a/specification/paths/Suggest-hscode.json
+++ b/specification/paths/Suggest-hscode.json
@@ -78,7 +78,8 @@
                         "example": "6115210000"
                       },
                       "vector_weight": {
-                        "type": "float",
+                        "type": "number",
+                        "format": "float",
                         "example": 83.45
                       },
                       "product_description": {

--- a/specification/schemas/contracts/Contract.json
+++ b/specification/schemas/contracts/Contract.json
@@ -20,8 +20,9 @@
               "$ref": "#/components/schemas/Currency"
             },
             "volumetric_weight_divisor_factor": {
-              "type": "integer",
-              "default": 1
+              "type": "number",
+              "format": "float",
+              "default": 1.0
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"

--- a/specification/schemas/contracts/Contract.json
+++ b/specification/schemas/contracts/Contract.json
@@ -22,7 +22,8 @@
             "volumetric_weight_divisor_factor": {
               "type": "number",
               "format": "float",
-              "default": 1.0
+              "default": 1.0,
+              "description": "If your contractual agreements with the carrier contain a <a href=\"https://docs.myparcel.com/api/resources/shipments/physical-properties/volumetric-weight.html\"/>volumetric weight formula</a> that uses a different divisor than the `volumetric_weight_divisor` on our Service resource, you can use this factor to increase or decrease the divisor. For example a factor of 1.25 would change a divisor of 4000 to 5000."
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"

--- a/specification/schemas/contracts/Contract.json
+++ b/specification/schemas/contracts/Contract.json
@@ -8,9 +8,6 @@
         "attributes": {
           "type": "object",
           "properties": {
-            "currency": {
-              "$ref": "#/components/schemas/Currency"
-            },
             "name": {
               "type": "string",
               "example": "My Custom Contract"
@@ -18,6 +15,13 @@
             "status": {
               "type": "string",
               "example": "active"
+            },
+            "currency": {
+              "$ref": "#/components/schemas/Currency"
+            },
+            "volumetric_weight_divisor_factor": {
+              "type": "integer",
+              "default": 1
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"

--- a/specification/schemas/contracts/ContractResponse.json
+++ b/specification/schemas/contracts/ContractResponse.json
@@ -13,9 +13,10 @@
       "properties": {
         "attributes": {
           "required": [
-            "currency",
             "name",
             "status",
+            "currency",
+            "volumetric_weight_divisor_factor",
             "created_at",
             "updated_at"
           ],

--- a/specification/schemas/integrations/OrderAnalytics.json
+++ b/specification/schemas/integrations/OrderAnalytics.json
@@ -39,8 +39,7 @@
           "data": {
             "type": "array",
             "items": {
-              "type": "number",
-              "format": "int",
+              "type": "integer",
               "description": "Order count for the selected date interval",
               "example": 102
             }

--- a/specification/schemas/returns/MostReturnedItem.json
+++ b/specification/schemas/returns/MostReturnedItem.json
@@ -27,7 +27,7 @@
           "format": "uri"
         },
         "amount": {
-          "type": "number"
+          "type": "integer"
         }
       }
     },
@@ -50,7 +50,7 @@
             "example": "Wrong Size"
           },
           "amount": {
-            "type": "number",
+            "type": "integer",
             "example": 10
           }
         }

--- a/specification/schemas/returns/ReturnAnalytics.json
+++ b/specification/schemas/returns/ReturnAnalytics.json
@@ -38,8 +38,7 @@
           "data": {
             "type": "array",
             "items": {
-              "type": "number",
-              "format": "int",
+              "type": "integer",
               "example": 102
             }
           }

--- a/specification/schemas/service-rates/ServiceRate.json
+++ b/specification/schemas/service-rates/ServiceRate.json
@@ -67,6 +67,7 @@
             },
             "volume_max": {
               "type": "number",
+              "format": "float",
               "example": 12.5,
               "description": "Volume in liters. (dm3)"
             },

--- a/specification/schemas/services/Service.json
+++ b/specification/schemas/services/Service.json
@@ -106,7 +106,7 @@
               "description": "Whether the volumetric weight of a shipment is taken into account when determining the price for a service."
             },
             "volumetric_weight_divisor": {
-              "type": "number",
+              "type": "integer",
               "example": 4000,
               "description": "The volumetric weight divisor is used to calculate the volumetric weight of a shipment. Multiplying the length (mm) x width (mm) x height (mm) of a shipment and dividing it by this number will result in the volumetric weight (g). See <a href=\"https://docs.myparcel.com/api/resources/shipments/physical-properties/volumetric-weight.html\"/>the documentation</a> for more information."
             },


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-6757
---
- Added `volumetric_weight_divisor_factor` float to the `Contract` resource.
- Adjusted existing number types to be defined according to [the OpenAPI Number definition](https://swagger.io/docs/specification/data-models/data-types/#numbers).
  > OpenAPI has two numeric types, `number` and `integer`, where number includes both integer and floating-point numbers. An optional `format` keyword serves as a hint for the tools to use a specific numeric type.