### PR TITLE
♿️ Support decimal weight filter on service-rates endpoint

### DIFF
--- a/specification/parameters/query-filter-weight.json
+++ b/specification/parameters/query-filter-weight.json
@@ -3,6 +3,6 @@
   "in": "query",
   "description": "Weight value in grams to filter by.",
   "schema": {
-    "type": "integer"
+    "type": "number"
   }
 }


### PR DESCRIPTION
This used to work before the latest release, so we're bringing back support for it.