### PR TITLE
🔥 Remove answer type from return questions

### DIFF
--- a/specification/paths/Returns-v1-questions.json
+++ b/specification/paths/Returns-v1-questions.json
@@ -123,8 +123,7 @@
                       "attributes": {
                         "required": [
                           "code",
-                          "description",
-                          "answer_type"
+                          "description"
                         ]
                       }
                     }

--- a/specification/schemas/return-questions/CreateReturnQuestionRequest.json
+++ b/specification/schemas/return-questions/CreateReturnQuestionRequest.json
@@ -25,13 +25,6 @@
                   }
                 }
               ]
-            },
-            "answer_type": {
-              "type": "string",
-              "enum": [
-                "text",
-                "boolean"
-              ]
             }
           }
         }

--- a/specification/schemas/return-questions/PatchReturnQuestionRequest.json
+++ b/specification/schemas/return-questions/PatchReturnQuestionRequest.json
@@ -20,13 +20,6 @@
                   }
                 }
               ]
-            },
-            "answer_type": {
-              "type": "string",
-              "enum": [
-                "text",
-                "boolean"
-              ]
             }
           }
         }

--- a/specification/schemas/return-questions/ReturnQuestion.json
+++ b/specification/schemas/return-questions/ReturnQuestion.json
@@ -35,13 +35,6 @@
                 }
               ],
               "description": "The value of the ``Accept-Language`` header determines the language in which the description is returned. If the ``Accept-Language`` header is missing, we default to ``en-GB``. If the User has the ``return_questions.manage`` scope and the ``Accept-Language`` header is set to ``*``, all descriptions will be returned in a key/value object."
-            },
-            "answer_type": {
-              "type": "string",
-              "enum": [
-                "text",
-                "boolean"
-              ]
             }
           }
         }

--- a/specification/schemas/return-questions/ReturnQuestionResponse.json
+++ b/specification/schemas/return-questions/ReturnQuestionResponse.json
@@ -13,8 +13,7 @@
         "attributes": {
           "required": [
             "code",
-            "description",
-            "answer_type"
+            "description"
           ]
         },
         "links": {


### PR DESCRIPTION
## Changes
- 🔥 Removed `answer_type` attribute from ReturnQuestions resource.