### PR TITLE
:lady_beetle: Shipment report filter should have country code as array

### DIFF
--- a/specification/schemas/reports/Report.json
+++ b/specification/schemas/reports/Report.json
@@ -151,7 +151,8 @@
                   ],
                   "properties": {
                     "country_code": {
-                      "$ref": "#/components/schemas/CountryCode"
+                      "type": "string",
+                      "pattern": "^([A-Z]{2},?)+$"
                     }
                   }
                 },
@@ -162,7 +163,8 @@
                   ],
                   "properties": {
                     "country_code": {
-                      "$ref": "#/components/schemas/CountryCode"
+                      "type": "string",
+                      "pattern": "^([A-Z]{2},?)+$"
                     }
                   }
                 }

--- a/specification/schemas/reports/Report.json
+++ b/specification/schemas/reports/Report.json
@@ -130,7 +130,7 @@
                 },
                 "current_status_code": {
                   "type": "array",
-                  "description": "Comma separated string of status codes to filter by. Only shipments with the a current status that corresponds with one of the status codes will be in the report.",
+                  "description": "Array of status codes to filter by. Only shipments with the a current status that corresponds with one of the status codes will be in the report.",
                   "items": {
                     "type": "string",
                     "example": "shipment-delivered"
@@ -138,7 +138,7 @@
                 },
                 "service_code": {
                   "type": "array",
-                  "description": "Comma separated string of service codes to filter by. Only shipments with a service that corresponds with one of the service codes will be in the report.",
+                  "description": "Array of service codes to filter by. Only shipments with a service that corresponds with one of the service codes will be in the report.",
                   "items": {
                     "type": "string",
                     "example": "dpd-next-day"
@@ -151,8 +151,10 @@
                   ],
                   "properties": {
                     "country_code": {
-                      "type": "string",
-                      "pattern": "^([A-Z]{2},?)+$"
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CountryCode"
+                      }
                     }
                   }
                 },
@@ -163,8 +165,10 @@
                   ],
                   "properties": {
                     "country_code": {
-                      "type": "string",
-                      "pattern": "^([A-Z]{2},?)+$"
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CountryCode"
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
I encountered this error when selecting multiple countries in the Report form when selecting multiple countries.

![image](https://github.com/user-attachments/assets/362819af-a4d3-43f0-992c-740b0a723c67)

~~In the back office code, we deliberately send a comma separated list of country codes to the API as filter. The API is also capable of handling this comma separated list of country codes.~~
~~The API Specification is where the problem lies. We have defined these inputs as being a CountryCode schema, but that does not support comma-separated entries.~~

~~Since the API supports this input, I believe our specification should allow it too.~~

The other filters all support arrays, so country codes should ha


## Changes
- Changed `filters.recipient_address.country_code` and `filters.sender_address.country_code` attributes on Report schema to ~~support comma separated~~ country codes as array.