### PR TITLE
:sparkles: Support timestamps for return report date filters.

### DIFF
--- a/specification/paths/Returns-v1-reports-count-report-entries.json
+++ b/specification/paths/Returns-v1-reports-count-report-entries.json
@@ -25,18 +25,26 @@
             "additionalProperties": false,
             "properties": {
               "data": {
-                "additionalProperties": false,
-                "properties": {
-                  "attributes": {
-                    "type": "object",
-                    "additionalProperties": false,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ReturnReport"
+                  },
+                  {
+                    "required": [
+                      "attributes"
+                    ],
                     "properties": {
-                      "filters": {
-                        "$ref": "#/components/schemas/ReturnReportFilters"
+                      "id": {
+                        "readOnly": true
+                      },
+                      "attributes": {
+                        "required": [
+                          "filters"
+                        ]
                       }
                     }
                   }
-                }
+                ]
               }
             }
           }
@@ -56,8 +64,11 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
+                  "required": [
+                    "total_entries"
+                  ],
                   "properties": {
-                    "count": {
+                    "total_entries": {
                       "type": "integer",
                       "example": 42
                     }

--- a/specification/schemas/return-reports/ReturnReportFilters.json
+++ b/specification/schemas/return-reports/ReturnReportFilters.json
@@ -10,13 +10,19 @@
       ],
       "properties": {
         "date_from": {
-          "type": "string",
-          "description": "Date string in YYYY-MM-DD format. Only returns created at >= this date will be in the report.",
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns created at >= this date will be in the report.",
           "example": "2024-02-01"
         },
         "date_to": {
-          "type": "string",
-          "description": "Date string in YYYY-MM-DD format. Only returns created at <= this date will be in the response.",
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns created at <= this date will be in the response.",
           "example": "2024-03-01"
         }
       }
@@ -30,13 +36,19 @@
       ],
       "properties": {
         "date_from": {
-          "type": "string",
-          "description": "Date string in YYYY-MM-DD format. Only returns approved at >= this date will be in the report.",
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns approved at >= this date will be in the report.",
           "example": "2024-02-01"
         },
         "date_to": {
-          "type": "string",
-          "description": "Date string in YYYY-MM-DD format.Only returns approved at <= this date will be in the response.",
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp.Only returns approved at <= this date will be in the response.",
           "example": "2024-03-01"
         }
       }
@@ -123,13 +135,19 @@
       ],
       "properties": {
         "date_from": {
-          "type": "string",
-          "description": "Date string in YYYY-MM-DD format. Only returns paid at >= this date will be in the report.",
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns paid at >= this date will be in the report.",
           "example": "2024-02-01"
         },
         "date_to": {
-          "type": "string",
-          "description": "Date string in YYYY-MM-DD format. Only returns paid at <= this date will be in the response.",
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns paid at <= this date will be in the response.",
           "example": "2024-03-01"
         }
       }

--- a/specification/schemas/return-reports/ReturnReportFilters.json
+++ b/specification/schemas/return-reports/ReturnReportFilters.json
@@ -12,7 +12,7 @@
         "date_from": {
           "type": [
             "string",
-            "number"
+            "integer"
           ],
           "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns created at >= this date will be in the report.",
           "example": "2024-02-01"
@@ -20,7 +20,7 @@
         "date_to": {
           "type": [
             "string",
-            "number"
+            "integer"
           ],
           "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns created at <= this date will be in the response.",
           "example": "2024-03-01"
@@ -38,7 +38,7 @@
         "date_from": {
           "type": [
             "string",
-            "number"
+            "integer"
           ],
           "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns approved at >= this date will be in the report.",
           "example": "2024-02-01"
@@ -46,7 +46,7 @@
         "date_to": {
           "type": [
             "string",
-            "number"
+            "integer"
           ],
           "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp.Only returns approved at <= this date will be in the response.",
           "example": "2024-03-01"
@@ -137,7 +137,7 @@
         "date_from": {
           "type": [
             "string",
-            "number"
+            "integer"
           ],
           "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns paid at >= this date will be in the report.",
           "example": "2024-02-01"
@@ -145,7 +145,7 @@
         "date_to": {
           "type": [
             "string",
-            "number"
+            "integer"
           ],
           "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns paid at <= this date will be in the response.",
           "example": "2024-03-01"


### PR DESCRIPTION
## Motivation
Until now, return reports only supported date strings. 
These date strings are time zone dependent. 
When our back office sends the date filter to our API, it will do so in the timezone of the user, which might differ than the time zone of our API. It then will wrongly include or exclude results of a day earlier or later, depending on the timezone of the user. 

Adding support for timestamps, means that the user can always send a unix timestamp, which will always be in the UTC timezone, leading to us exactly knowing which of the returns to include in the report.

## Changes
- ✨ Added support for numbers as date filters for return reports in order to respect timezone differences.