### PR TITLE
🔥  Removed postal code filter on return methods

### DIFF
--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -28,14 +28,6 @@
         }
       },
       {
-        "name": "filter[address_from][postal_code]",
-        "in": "query",
-        "description": "Postal code of origin location. Combine with `filter[address_from][country_code]` for more accurate results.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      {
         "name": "filter[shipping_and_return]",
         "in": "query",
         "description": "When set to true, the endpoint will return only shipping return methods that offer shipping and return service. However, in case that there is no shipping return method available, the endpoint will respond with all return methods, except label in the box, unless specified as a filter. When set to false, the endpoint will exclude all shipping and return return methods.",

--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -161,6 +161,9 @@
                         "properties": {
                           "default_weight": {
                             "description": "Required if the `return_type` is set to `shipment`."
+                          },
+                          "country_codes": {
+                            "description": "Country codes to which the return method applies. Codes are in ISO 3166-1 alpha-2 format. <b>It can be specified for store-drop-off and self-shipment return methods only.</b> Shipment return methods automatically set country code lists based on MyParcel.com shipping services configuration."
                           }
                         }
                       },

--- a/specification/schemas/return-methods/ReturnMethod.json
+++ b/specification/schemas/return-methods/ReturnMethod.json
@@ -24,6 +24,13 @@
               "type": "string",
               "description": "Required if the return_type attribute is `shipment`."
             },
+            "country_codes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "NL"
+              }
+            },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
             }

--- a/specification/schemas/return-methods/ReturnMethodResponse.json
+++ b/specification/schemas/return-methods/ReturnMethodResponse.json
@@ -15,7 +15,12 @@
           "required": [
             "return_type",
             "created_at"
-          ]
+          ],
+          "properties": {
+            "country_codes": {
+              "description": "Country codes to which the return method applies. Codes are in ISO 3166-1 alpha-2 format."
+            }
+          }
         },
         "links": {
           "readOnly": true,


### PR DESCRIPTION
# What's Changed
## Removed postal_code filtering
Me, @yoerriwalstra and @M4tini discussed together with Matt that the postal codes filtering wouldn't be necessary now and is unlikely to ever be for returns. Although main motivation was because of the complicated queries that we had to do and the following preg_match. Therefore we looked for reasons not to implement it. 

After Lars is back we can discuss with him if postal code-based rates will be a thing for returns, and think of how to implement it in a simple way.
## Optional `country_codes` for non-shipment return methods
Merchants should be able to specify store-drop-off return methods to specific countries only. That's why the `country_codes` field was also added.   