### PR TITLE
:recycle: Return report date filters should be ISO 8601 format.

### DIFF
--- a/specification/schemas/reports/Report.json
+++ b/specification/schemas/reports/Report.json
@@ -30,7 +30,7 @@
                         "number"
                       ],
                       "description": "Date string in ISO 8601 format or unix timestamp. Only shipments created at >= this date will be in the report.",
-                      "example": "2020-01-01"
+                      "example": "2020-01-01T00:00:00+02:00"
                     },
                     "date_to": {
                       "type": [
@@ -38,7 +38,7 @@
                         "number"
                       ],
                       "description": "Date string in ISO 8601 format or unix timestamp. Only shipments created at <= this date will be in the response.",
-                      "example": "2020-03-31"
+                      "example": "1585691999"
                     }
                   }
                 },
@@ -56,7 +56,7 @@
                         "number"
                       ],
                       "description": "Date string in ISO 8601 format or unix timestamp. Only shipments registered at >= this date will be in the report.",
-                      "example": "2020-01-01"
+                      "example": "2020-01-01T00:00:00+02:00"
                     },
                     "date_to": {
                       "type": [
@@ -64,7 +64,7 @@
                         "number"
                       ],
                       "description": "Date string in ISO 8601 format or unix timestamp. Only shipments registered at <= this date will be in the response.",
-                      "example": "2020-03-31"
+                      "example": "1585691999"
                     }
                   }
                 },

--- a/specification/schemas/return-reports/ReturnReportFilters.json
+++ b/specification/schemas/return-reports/ReturnReportFilters.json
@@ -14,16 +14,16 @@
             "string",
             "integer"
           ],
-          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns created at >= this date will be in the report.",
-          "example": "2024-02-01"
+          "description": "Date string in ISO 8601 format or unix timestamp. Only returns paid at >= this date will be in the report.",
+          "example": "2024-02-01T00:00:00+02:00"
         },
         "date_to": {
           "type": [
             "string",
             "integer"
           ],
-          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns created at <= this date will be in the response.",
-          "example": "2024-03-01"
+          "description": "Date string in ISO 8601 format or unix timestamp. Only returns paid at <= this date will be in the response.",
+          "example": "1709333999"
         }
       }
     },
@@ -40,16 +40,16 @@
             "string",
             "integer"
           ],
-          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns approved at >= this date will be in the report.",
-          "example": "2024-02-01"
+          "description": "Date string in ISO 8601 format or unix timestamp. Only returns paid at >= this date will be in the report.",
+          "example": "2024-02-01T00:00:00+02:00"
         },
         "date_to": {
           "type": [
             "string",
             "integer"
           ],
-          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp.Only returns approved at <= this date will be in the response.",
-          "example": "2024-03-01"
+          "description": "Date string in ISO 8601 format or unix timestamp. Only returns paid at <= this date will be in the response.",
+          "example": "1709333999"
         }
       }
     },
@@ -139,16 +139,16 @@
             "string",
             "integer"
           ],
-          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns paid at >= this date will be in the report.",
-          "example": "2024-02-01"
+          "description": "Date string in ISO 8601 format or unix timestamp. Only returns paid at >= this date will be in the report.",
+          "example": "2024-02-01T00:00:00+02:00"
         },
         "date_to": {
           "type": [
             "string",
             "integer"
           ],
-          "description": "Date string in YYYY-MM-DD format (UTC) or unix timestamp. Only returns paid at <= this date will be in the response.",
-          "example": "2024-03-01"
+          "description": "Date string in ISO 8601 format or unix timestamp. Only returns paid at <= this date will be in the response.",
+          "example": "1709333999"
         }
       }
     },


### PR DESCRIPTION
## Changes
- Updated the Return report filters to specify ISO 8601 date format
- Updated Report date filter examples to correctly be in ISO 8601 format