### PR TITLE
:lady_beetle: Country code filter should accept multiple country codes.

### DIFF
--- a/specification/schemas/return-reports/ReturnReportFilters.json
+++ b/specification/schemas/return-reports/ReturnReportFilters.json
@@ -175,14 +175,17 @@
       ]
     },
     "consumer_country_code": {
-      "allOf": [
-        {
-          "$ref": "#/components/schemas/CountryCode"
-        },
-        {
-          "description": "Filter entries by return's consumer country code."
-        }
-      ]
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CountryCode"
+          },
+          {
+            "description": "Filter entries by return's consumer country code."
+          }
+        ]
+      }
     },
     "consumer_email": {
       "allOf": [


### PR DESCRIPTION
## Changes
- The consumer country code filter on return reports should be of type array, to allow the user to select multiple countries when making a report.
- This is also in line with the reports for shipments, which also support selecting multiple.