### PR TITLE
:lady_beetle: Return item comment too long

### DIFF
--- a/specification/schemas/returns/PostReturnItem.json
+++ b/specification/schemas/returns/PostReturnItem.json
@@ -58,6 +58,7 @@
             "string",
             "null"
           ],
+          "maxLength": 255,
           "description": "Additional information regarding the reason for the return."
         },
         "questions": {


### PR DESCRIPTION
**Changes**
- Add `maxLength` constraint to return item comment