### PR TITLE
🚚 Move the ServiceOption `values_format` to its attributes where it belongs

### DIFF
--- a/specification/schemas/service-options/ServiceOption.json
+++ b/specification/schemas/service-options/ServiceOption.json
@@ -27,6 +27,25 @@
               "type": "string",
               "maxLength": 255,
               "example": "delivery-window:sunday"
+            },
+            "values_format": {
+              "type": "object",
+              "example": {
+                "required": [
+                  "amount",
+                  "currency"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "amount": {
+                    "type": "integer"
+                  },
+                  "currency": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "JSON Schema specification of the optional `values` property in the meta of this service option, when posted as a relationship of a shipment. See `data.relationships.service_options.data.*.meta` in POST `/shipments` request body."
             }
           }
         }

--- a/specification/schemas/service-options/ServiceOptionResponse.json
+++ b/specification/schemas/service-options/ServiceOptionResponse.json
@@ -17,33 +17,6 @@
             "category"
           ]
         },
-        "meta": {
-          "type": "object",
-          "required": [
-            "values_format"
-          ],
-          "properties": {
-            "values_format": {
-              "type": "object",
-              "example": {
-                "required": [
-                  "amount",
-                  "currency"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "amount": {
-                    "type": "integer"
-                  },
-                  "currency": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "JSON Schema specification of the optional `values` property in the meta of this service option, when posted as a relationship of a shipment. See `data.relationships.service_options.data.*.meta` in POST `/shipments` request body."
-            }
-          }
-        },
         "links": {
           "readOnly": true,
           "type": "object",

--- a/specification/schemas/shipments/Shipment.json
+++ b/specification/schemas/shipments/Shipment.json
@@ -372,7 +372,7 @@
                                 "properties": {
                                   "values": {
                                     "type": "object",
-                                    "description": "Optional meta values specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash-on-delivery options. See the service option's `values_format` meta property for specific requirements per service option.",
+                                    "description": "Optional meta values specifically for this service option. Some service options require extra input, like `amount` and `currency` for cash-on-delivery options. See the service option's `values_format` attribute for specific requirements per service option.",
                                     "example": {
                                       "amount": 1200,
                                       "currency": "EUR"


### PR DESCRIPTION
We might have intended for `values_format` to be in the meta of service-options, but we implemented it as an attribute.
I think this meta is a mistake and most likely confused with `values`, which DO go in a meta (when used as relationship).

Since we also have implemented all other `..._format` json-schema properties as attributes, I think this is the way to go.

> FYI - our API and docs are already aligned + our app flattens everything onto a Model so that will work fine as well.