### PR TITLE
✨  Introduced new endpoint `POST /returns/v1/return-methods/resolve`

### DIFF
--- a/specification/paths.json
+++ b/specification/paths.json
@@ -236,6 +236,9 @@
   "/returns/v1/return-methods": {
     "$ref": "./paths/Returns-v1-return-methods.json"
   },
+  "/returns/v1/return-methods/resolve": {
+    "$ref": "./paths/Returns-v1-return-methods-resolve.json"
+  },
   "/returns/v1/return-methods/{return_method_id}": {
     "$ref": "./paths/Returns-v1-return-methods-return_method_id.json"
   },

--- a/specification/paths/Returns-v1-return-methods-resolve.json
+++ b/specification/paths/Returns-v1-return-methods-resolve.json
@@ -1,0 +1,100 @@
+{
+  "post": {
+    "tags": [
+      "ReturnMethods"
+    ],
+    "security": [
+      {
+        "OAuth2": [
+          "returns.manage"
+        ]
+      }
+    ],
+    "summary": "Resolve matching return methods.",
+    "description": "This endpoint finds out what return methods match data for a return.",
+    "requestBody": {
+      "description": "Return input data.",
+      "required": true,
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "required": [
+                  "shop_id",
+                  "consumer_address"
+                ],
+                "properties": {
+                  "shop_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^[a-f\\d]{8}(-[a-f\\d]{4}){3}-[a-f\\d]{12}$",
+                    "example": "35eddf50-1d84-47a3-8479-6bfda729cd99"
+                  },
+                  "consumer_address": {
+                    "required": [
+                      "country_code"
+                    ],
+                    "properties": {
+                      "country_code": {
+                        "$ref": "#/components/schemas/CountryCode"
+                      }
+                    }
+                  },
+                  "weight": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "example": 5000,
+                    "description": "Weight in grams."
+                  },
+                  "shipping_and_return": {
+                    "type": "boolean",
+                    "example": true,
+                    "description": "When set to `true`, the endpoint will return only shipping return methods that offer shipping and return service. However, in case that there is no shipping and return method available, the endpoint will respond with all return methods, except label in the box (unless `label_in_the_box` field is set to `true`). When `shipping_and_return` is set to `false` (or omitted), the endpoint will exclude all shipping and return return methods."
+                  },
+                  "label_in_the_box": {
+                    "type": "boolean",
+                    "example": true,
+                    "description": "When set to `true`, the endpoint will return only shipping return methods that offer label in the box service. However, in case that there is no label in the box method available, the endpoint will respond with all return methods, except shipping and return (unless `shipping_and_return` field is set to `true`). When `label_in_the_box` is set to `false` (or omitted), the endpoint will exclude all label in the box return methods."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "Retrieved the return methods.",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "data"
+              ],
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReturnMethodResponse"
+                  }
+                },
+                "included": {
+                  "$ref": "#/components/schemas/ReturnMethodIncludes"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -14,14 +14,29 @@
     "description": "This endpoint retrieves return methods available to your API client.",
     "parameters": [
       {
-        "$ref": "#/components/parameters/query-filter-shop"
+        "allOf": [
+          {
+            "$ref": "#/components/parameters/query-filter-shop"
+          },
+          {
+            "deprecated": true
+          }
+        ]
       },
       {
-        "$ref": "#/components/parameters/query-filter-weight"
+        "allOf": [
+          {
+            "$ref": "#/components/parameters/query-filter-weight"
+          },
+          {
+            "deprecated": true
+          }
+        ]
       },
       {
         "name": "filter[address_from][country_code]",
         "in": "query",
+        "deprecated": true,
         "description": "Country code of origin location. Combine with `filter[address_from][postal_code]` for more accurate results.",
         "schema": {
           "$ref": "#/components/schemas/CountryCode"
@@ -29,6 +44,7 @@
       },
       {
         "name": "filter[shipping_and_return]",
+        "deprecated": true,
         "in": "query",
         "description": "When set to true, the endpoint will return only shipping return methods that offer shipping and return service. However, in case that there is no shipping return method available, the endpoint will respond with all return methods, except label in the box, unless specified as a filter. When set to false, the endpoint will exclude all shipping and return return methods.",
         "schema": {
@@ -37,6 +53,7 @@
       },
       {
         "name": "filter[label_in_the_box]",
+        "deprecated": true,
         "in": "query",
         "description": "When set to true, the endpoint will return only return methods that offer label in the box service. However, in case that there is no label in the box return method available, the endpoint will respond with all return methods, except shipping and return, unless specified as a filter. When set to false, the endpoint will exclude all label in the box return methods.",
         "schema": {

--- a/specification/schemas/returns/ReturnRequest.json
+++ b/specification/schemas/returns/ReturnRequest.json
@@ -12,11 +12,7 @@
               "type": "array",
               "minItems": 1,
               "items": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PostReturnItem"
-                  }
-                ]
+                "$ref": "#/components/schemas/PostReturnItem"
               }
             }
           }


### PR DESCRIPTION
# What's Changed
I made some small changes compared to the implementation in the ticket:
- I decided not to include the entire create return request body just yet. That's because some things are too much, such as item attachments
- I did not add the `type` and `attributes`, not `relationships` in the input as they all seemed unnecessary. The request does not really have a type, because we are not creating a resource.
- I did not include the entire address object as only the country code is relevant at the moment. We can expand when needed with more fields
