### PR TITLE
👌🏻  Added carrier and service fields in return methods meta for easy access

### DIFF
--- a/specification/paths/Returns-v1-return-methods-resolve.json
+++ b/specification/paths/Returns-v1-return-methods-resolve.json
@@ -86,9 +86,6 @@
                   "items": {
                     "$ref": "#/components/schemas/ReturnMethodResponse"
                   }
-                },
-                "included": {
-                  "$ref": "#/components/schemas/ReturnMethodIncludes"
                 }
               }
             }

--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -17,14 +17,13 @@
         "$ref": "#/components/parameters/query-filter-shop"
       },
       {
-        "allOf": [
-          {
-            "$ref": "#/components/parameters/query-filter-weight"
-          },
-          {
-            "deprecated": true
-          }
-        ]
+        "name": "filter[weight]",
+        "in": "query",
+        "deprecated": true,
+        "description": "Weight value in grams to filter by.",
+        "schema": {
+          "type": "number"
+        }
       },
       {
         "name": "filter[address_from][country_code]",

--- a/specification/schemas/return-methods/ReturnMethodMeta.json
+++ b/specification/schemas/return-methods/ReturnMethodMeta.json
@@ -3,6 +3,59 @@
   "properties": {
     "price": {
       "$ref": "#/components/schemas/Price"
+    },
+    "carrier": {
+      "required": [
+        "name",
+        "code",
+        "logo_url"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "PostNL"
+        },
+        "code": {
+          "type": "string",
+          "example": "postnl"
+        },
+        "logo_url": {
+          "type": "string",
+          "example": "https://cdn.myparcel.com/images/myparcelcom-black.svg",
+          "description": "Logo image URL"
+        }
+      }
+    },
+    "service": {
+      "required": [
+        "name",
+        "code"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "maxLength": 255,
+          "example": "PostNL Heen en Terug"
+        },
+        "code": {
+          "type": "string",
+          "maxLength": 255,
+          "example": "postnl-heen-en-terug",
+          "description": "Slug of the service"
+        },
+        "is_label_in_the_box": {
+          "type": "boolean",
+          "example": true,
+          "default": false,
+          "description": "Indicates whether the service uses an implementation of label in the box, where the return label of a shipment is provided in the shipping box."
+        },
+        "is_shipping_and_return": {
+          "type": "boolean",
+          "example": false,
+          "default": false,
+          "description": "Indicates whether the service uses an implementation of shipping and return, where the shipping label can be reused for returns."
+        }
+      }
     }
   }
 }

--- a/specification/schemas/return-methods/ReturnMethodMeta.json
+++ b/specification/schemas/return-methods/ReturnMethodMeta.json
@@ -21,7 +21,7 @@
         },
         "logo_url": {
           "type": "string",
-          "example": "https://cdn.myparcel.com/images/myparcelcom-black.svg",
+          "example": "https://cdn.myparcel.com/carriers/PostNL.svg",
           "description": "Logo image URL"
         }
       }

--- a/specification/schemas/return-methods/ReturnMethodMeta.json
+++ b/specification/schemas/return-methods/ReturnMethodMeta.json
@@ -29,7 +29,9 @@
     "service": {
       "required": [
         "name",
-        "code"
+        "code",
+        "is_label_in_the_box",
+        "is_shipping_and_return"
       ],
       "properties": {
         "name": {


### PR DESCRIPTION
# What's Changed
Some basic carrier and service fields like name, code and logo URL are always needed when the resolve return methods endpoint will be called. Therefore, it is not necessary to have them as relationship includes