### PR TITLE
:lady_beetle: Added size and brand to item feature annotation enum.

### DIFF
--- a/specification/schemas/return-orders/ItemFeature.json
+++ b/specification/schemas/return-orders/ItemFeature.json
@@ -24,7 +24,9 @@
         "null"
       ],
       "enum": [
-        "color"
+        "color",
+        "brand",
+        "size"
       ]
     }
   }


### PR DESCRIPTION
## Changes
- 🐞 Added `brand` and `size` to `annotation` property of return/order `item.features` attribute.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-7031
- https://myparcelcombv.atlassian.net/browse/MP-6897