### PR TITLE
MP-7072 Last login user attribute

### DIFF
--- a/specification/paths/Users.json
+++ b/specification/paths/Users.json
@@ -26,11 +26,20 @@
         }
       },
       {
+        "$ref": "#/components/parameters/query-filter-created_at-date_from"
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-created_at-date_to"
+      },
+      {
         "name": "filter[last_login_before]",
         "in": "query",
-        "description": "Retrieve users who last logged in before the specified time.",
+        "description": "Date string in ISO 8601 format or unix timestamp. Only resources created at >= this date will be in the response.",
         "schema": {
-          "$ref": "#/components/schemas/Timestamp"
+          "type": [
+            "string",
+            "number"
+          ]
         }
       }
     ],

--- a/specification/paths/Users.json
+++ b/specification/paths/Users.json
@@ -24,6 +24,14 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "name": "filter[last_login_before]",
+        "in": "query",
+        "description": "Retrieve users who last logged in before the specified time.",
+        "schema": {
+          "$ref": "#/components/schemas/Timestamp"
+        }
       }
     ],
     "responses": {

--- a/specification/schemas/users/User.json
+++ b/specification/schemas/users/User.json
@@ -58,6 +58,9 @@
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
+            },
+            "last_login": {
+              "$ref": "#/components/schemas/Timestamp"
             }
           }
         }

--- a/specification/schemas/users/UserResponse.json
+++ b/specification/schemas/users/UserResponse.json
@@ -18,7 +18,8 @@
             "locale",
             "status",
             "has_mfa_enabled",
-            "created_at"
+            "created_at",
+            "last_login"
           ]
         },
         "links": {


### PR DESCRIPTION
Changes:
- Added a `last_login` to the User schema
- Added the `filter[last_login_before]` to enable filtering users that have not been logged in for a while
- Exposed `last_login` in the UserResponse schema

Ticket: https://myparcelcombv.atlassian.net/browse/MP-7072
