### PR TITLE
Reintroduce "MP-7072 Last login user attribute""

### DIFF
--- a/specification/paths/Users.json
+++ b/specification/paths/Users.json
@@ -32,13 +32,26 @@
         "$ref": "#/components/parameters/query-filter-created_at-date_to"
       },
       {
-        "name": "filter[last_login_before]",
+        "name": "filter[last_active_before]",
         "in": "query",
-        "description": "Date string in ISO 8601 format or unix timestamp. Only resources created at >= this date will be in the response.",
+        "description": "Date string in ISO 8601 format or unix timestamp. Only resources created before this date will be in the response.",
         "schema": {
           "type": [
             "string",
             "number"
+          ]
+        }
+      },
+      {
+        "name": "filter[status]",
+        "in": "query",
+        "description": "The status of the user.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "active",
+            "blocked",
+            "pending"
           ]
         }
       }

--- a/specification/paths/Users.json
+++ b/specification/paths/Users.json
@@ -24,6 +24,23 @@
         "schema": {
           "type": "string"
         }
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-created_at-date_from"
+      },
+      {
+        "$ref": "#/components/parameters/query-filter-created_at-date_to"
+      },
+      {
+        "name": "filter[last_login_before]",
+        "in": "query",
+        "description": "Date string in ISO 8601 format or unix timestamp. Only resources created at >= this date will be in the response.",
+        "schema": {
+          "type": [
+            "string",
+            "number"
+          ]
+        }
       }
     ],
     "responses": {

--- a/specification/schemas/users/User.json
+++ b/specification/schemas/users/User.json
@@ -58,6 +58,9 @@
             },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
+            },
+            "last_login": {
+              "$ref": "#/components/schemas/Timestamp"
             }
           }
         }

--- a/specification/schemas/users/User.json
+++ b/specification/schemas/users/User.json
@@ -59,7 +59,7 @@
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
             },
-            "last_login": {
+            "last_active": {
               "$ref": "#/components/schemas/Timestamp"
             }
           }

--- a/specification/schemas/users/UserResponse.json
+++ b/specification/schemas/users/UserResponse.json
@@ -19,7 +19,7 @@
             "status",
             "has_mfa_enabled",
             "created_at",
-            "last_login"
+            "last_active"
           ]
         },
         "links": {

--- a/specification/schemas/users/UserResponse.json
+++ b/specification/schemas/users/UserResponse.json
@@ -18,7 +18,8 @@
             "locale",
             "status",
             "has_mfa_enabled",
-            "created_at"
+            "created_at",
+            "last_login"
           ]
         },
         "links": {


### PR DESCRIPTION
Because of MyParcelCOM/api-specification#1148 I am creating this PR that reintroduces the reverted commits. 

The cause of this is because the original PR MyParcelCOM/api-specification#1147 was merged too early. Should always be at once with the api side of thing so that other pipelines are not impacted.