### PR TITLE
:sparkles: Add `address` property to ReturnMethod and Return schemas

### DIFF
--- a/specification/paths/Returns-v1-returns.json
+++ b/specification/paths/Returns-v1-returns.json
@@ -178,16 +178,7 @@
                           "order_reference",
                           "items",
                           "consumer_address"
-                        ],
-                        "properties": {
-                          "consumer_address": {
-                            "required": [
-                              "street_1",
-                              "city",
-                              "country_code"
-                            ]
-                          }
-                        }
+                        ]
                       },
                       "relationships": {
                         "required": [

--- a/specification/schemas/return-methods/ReturnMethod.json
+++ b/specification/schemas/return-methods/ReturnMethod.json
@@ -45,6 +45,22 @@
                 "example": "NL"
               }
             },
+            "address": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BaseAddress"
+                },
+                {
+                  "required": [
+                    "first_name",
+                    "last_name",
+                    "street_1",
+                    "city",
+                    "country_code"
+                  ]
+                }
+              ]
+            },
             "created_at": {
               "$ref": "#/components/schemas/Timestamp"
             }

--- a/specification/schemas/returns/Return.json
+++ b/specification/schemas/returns/Return.json
@@ -16,6 +16,23 @@
               "maxLength": 255,
               "example": "#0001-my-order-reference"
             },
+            "address": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BaseAddress"
+                },
+                {
+                  "required": [
+                    "first_name",
+                    "last_name",
+                    "street_1",
+                    "city",
+                    "country_code"
+                  ],
+                  "description": "The destination address of the return. Defaults to the shop's return address."
+                }
+              ]
+            },
             "consumer_address": {
               "allOf": [
                 {
@@ -29,7 +46,8 @@
                     "city",
                     "country_code",
                     "email"
-                  ]
+                  ],
+                  "description": "The address of the consumer."
                 }
               ]
             },

--- a/specification/schemas/returns/ReturnResponse.json
+++ b/specification/schemas/returns/ReturnResponse.json
@@ -15,6 +15,7 @@
         "attributes": {
           "required": [
             "order_reference",
+            "address",
             "consumer_address",
             "has_preferred_outcome_refund",
             "has_preferred_outcome_exchange",


### PR DESCRIPTION
**Related issue**
https://myparcelcombv.atlassian.net/browse/MP-7080

**TODO**
* [ ] merge together with related API PR (under construction) to prevent pipelines from breaking over missing required property in the response