### PR TITLE
:lady_beetle: removed the last_active field from UserResponse.json required fields

### DIFF
--- a/specification/schemas/users/UserResponse.json
+++ b/specification/schemas/users/UserResponse.json
@@ -18,8 +18,7 @@
             "locale",
             "status",
             "has_mfa_enabled",
-            "created_at",
-            "last_active"
+            "created_at"
           ]
         },
         "links": {


### PR DESCRIPTION
Small bug with the addition `last_active` to the UserResponse required fields causing the schema to mismatch the API as it is actually not required.