### PR TITLE
👽️ Add the manifest document type

### DIFF
--- a/specification/schemas/files/DocumentType.json
+++ b/specification/schemas/files/DocumentType.json
@@ -5,6 +5,7 @@
     "printcode",
     "customs-declaration-form",
     "commercial-invoice",
+    "manifest",
     "manifest-itemized",
     "manifest-summarized",
     "manifest-csv",


### PR DESCRIPTION
Fix for: https://app.rollbar.com/a/myparcelcom/fix/item/api/9288

Our [carrier-specification](https://carrier-specification.myparcel.com/#tag/Manifests/paths/~1manifests/post) response is designed to return 3 file types: `label` + `printcode` + `manifest`

Because of that, our api-specification and API should also support these document types.