### PR TITLE
🔥  Removed legacy `GET /returns/v1/return-methods` filters

### DIFF
--- a/specification/paths/Returns-v1-return-methods.json
+++ b/specification/paths/Returns-v1-return-methods.json
@@ -17,42 +17,6 @@
         "$ref": "#/components/parameters/query-filter-shop"
       },
       {
-        "name": "filter[weight]",
-        "in": "query",
-        "deprecated": true,
-        "description": "Weight value in grams to filter by.",
-        "schema": {
-          "type": "number"
-        }
-      },
-      {
-        "name": "filter[address_from][country_code]",
-        "in": "query",
-        "deprecated": true,
-        "description": "Country code of origin location. Combine with `filter[address_from][postal_code]` for more accurate results.",
-        "schema": {
-          "$ref": "#/components/schemas/CountryCode"
-        }
-      },
-      {
-        "name": "filter[shipping_and_return]",
-        "deprecated": true,
-        "in": "query",
-        "description": "When set to true, the endpoint will return only shipping return methods that offer shipping and return service. However, in case that there is no shipping return method available, the endpoint will respond with all return methods, except label in the box, unless specified as a filter. When set to false, the endpoint will exclude all shipping and return return methods.",
-        "schema": {
-          "type": "boolean"
-        }
-      },
-      {
-        "name": "filter[label_in_the_box]",
-        "deprecated": true,
-        "in": "query",
-        "description": "When set to true, the endpoint will return only return methods that offer label in the box service. However, in case that there is no label in the box return method available, the endpoint will respond with all return methods, except shipping and return, unless specified as a filter. When set to false, the endpoint will exclude all label in the box return methods.",
-        "schema": {
-          "type": "boolean"
-        }
-      },
-      {
         "name": "include",
         "in": "query",
         "description": "Comma separated string of the relationship names you want to include the data of.<br>The relationships that can be included are:<ul><li>`shop`</li><li>`service`</li><li>`service_options`</li><li>`contract`</li></ul>",


### PR DESCRIPTION
This pull request removes deprecated query parameters from the `GET /returns/v1/return-methods` endpoint definition.

Removal of deprecated query parameters:

* [`filter[weight]`](diffhunk://#diff-2197558b82614f3746db0ecec0b5578a6b8f9dae22bbc2e0f8360a089e27877cL19-L54): Removed the deprecated query parameter for filtering by weight in grams.
* [`filter[address_from][country_code]`](diffhunk://#diff-2197558b82614f3746db0ecec0b5578a6b8f9dae22bbc2e0f8360a089e27877cL19-L54): Removed the deprecated query parameter for filtering by the country code of the origin location.
* [`filter[shipping_and_return]`](diffhunk://#diff-2197558b82614f3746db0ecec0b5578a6b8f9dae22bbc2e0f8360a089e27877cL19-L54): Removed the deprecated query parameter for filtering return methods that offer shipping and return services.
* [`filter[label_in_the_box]`](diffhunk://#diff-2197558b82614f3746db0ecec0b5578a6b8f9dae22bbc2e0f8360a089e27877cL19-L54): Removed the deprecated query parameter for filtering return methods that offer label in the box service.