### PR TITLE
MP-7122 Add countries from attribute to contract template schema

### DIFF
--- a/specification/paths/Contracts-v1-templates.json
+++ b/specification/paths/Contracts-v1-templates.json
@@ -26,6 +26,14 @@
       },
       {
         "$ref": "#/components/parameters/query-filter-carrier"
+      },
+      {
+        "name": "filter[countries_from]",
+        "in": "query",
+        "description": "Comma separated string of country codes to filter by.",
+        "schema": {
+          "type": "string"
+        }
       }
     ],
     "responses": {

--- a/specification/schemas/contract-templates/ContractTemplateResponse.json
+++ b/specification/schemas/contract-templates/ContractTemplateResponse.json
@@ -15,8 +15,19 @@
           "required": [
             "name",
             "currency",
+            "countries_from",
             "created_at"
-          ]
+          ],
+          "properties": {
+            "countries_from": {
+              "readOnly": true,
+              "type": "array",
+              "description": "Indicates the origin countries of the services related to this contract template.",
+              "items": {
+                "$ref": "#/components/schemas/CountryCode"
+              }
+            }
+          }
         },
         "relationships": {
           "required": [


### PR DESCRIPTION
## Changes
- ✨ Added `countries_from` attribute to ContractTemplate schema.
- ✨ Added `filter[countries_from]` query param to the GET endpoint for contract templates

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-7122

## Notes 
I implore the reviewer to come up with an alternative name for this attribute if they can think of one.