### PR TITLE
:lady_beetle: MP-7150 Fixed allowed types for integration configure values.

### DIFF
--- a/specification/paths/Marketplaces-v1-marketplaces-code-configure-shop-id.json
+++ b/specification/paths/Marketplaces-v1-marketplaces-code-configure-shop-id.json
@@ -59,7 +59,11 @@
                           "example": "orderPrefix"
                         },
                         "value": {
-                          "type": "string",
+                          "type": [
+                            "string",
+                            "number",
+                            "boolean"
+                          ],
                           "example": "shopify_"
                         }
                       }

--- a/specification/paths/Shops-shop_id-integrations-integration_id-configure.json
+++ b/specification/paths/Shops-shop_id-integrations-integration_id-configure.json
@@ -60,7 +60,11 @@
                           "example": "orderPrefix"
                         },
                         "value": {
-                          "type": "string",
+                          "type": [
+                            "string",
+                            "number",
+                            "boolean"
+                          ],
                           "example": "shopify_"
                         }
                       }


### PR DESCRIPTION
## Changes
- Updated the allowed type for `value` property in configure integration endpoint to `string`, `number` or `boolean`.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-7150