### PR TITLE
🔥 Remove unused payments resource_type from statuses

### DIFF
--- a/specification/schemas/statuses/Status.json
+++ b/specification/schemas/statuses/Status.json
@@ -52,7 +52,6 @@
               "type": "string",
               "enum": [
                 "invoices",
-                "payments",
                 "reports",
                 "returns",
                 "shipments"


### PR DESCRIPTION
In addition to https://github.com/MyParcelCOM/api-specification/pull/1174 we should also get rid of this non-existing resource type.