### PR TITLE
♻️ Remove `country` filter and add `broker` filter to the system-messages endpoint

### DIFF
--- a/specification/parameters.json
+++ b/specification/parameters.json
@@ -146,6 +146,9 @@
   "path-user_id": {
     "$ref": "./parameters/path-user_id.json"
   },
+  "path-wms_integration_code": {
+    "$ref": "./parameters/path-wms_integration_code.json"
+  },
   "path-zone_id": {
     "$ref": "./parameters/path-zone_id.json"
   },

--- a/specification/paths/SystemMessages.json
+++ b/specification/paths/SystemMessages.json
@@ -14,12 +14,7 @@
     "description": "This endpoint retrieves system messages. These are informative messages about our system or a specific type of resource.",
     "parameters": [
       {
-        "name": "filter[country]",
-        "in": "query",
-        "description": "Country code of system messages to filter by. Using this filter will also include system-wide messages.",
-        "schema": {
-          "$ref": "#/components/schemas/CountryCode"
-        }
+        "$ref": "#/components/parameters/query-filter-broker"
       }
     ],
     "responses": {

--- a/specification/schemas/system-messages/SystemMessage.json
+++ b/specification/schemas/system-messages/SystemMessage.json
@@ -14,16 +14,6 @@
               "maxLength": 255,
               "example": "Houston, we've had a problem."
             },
-            "country_code": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/CountryCode"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "level": {
               "type": "string",
               "enum": [


### PR DESCRIPTION
- We do not use the `country_code` attribute or the `country` filter when working with system messages.
- We do want to start using the `broker` filter when scoping the backoffice to a single broker.
- I also added a missing entry to the `parameters.json`.