### PR TITLE
:sparkles: Allow longer marketing text fields on Shop return branding.

### DIFF
--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -114,7 +114,7 @@
                           ],
                           "description": "Title of the free input text section of (approved) return emails",
                           "example": "Seasonal sample sale",
-                          "maxLength": 100
+                          "maxLength": 120
                         },
                         "marketing_content": {
                           "type": [
@@ -123,7 +123,7 @@
                           ],
                           "description": "Rich text content of the free input text section of (approved) return emails",
                           "example": "We have an <b>awesome seasonal sample</b> sale in store next month! <a>Click here</a> to take a sneak peek.",
-                          "maxLength": 250
+                          "maxLength": 500
                         },
                         "customer_service_phone": {
                           "type": [


### PR DESCRIPTION
## Changes
- ✨ Updated the max length on shop's `branding.returns.email_content.marketing_title` to 120 characters.
- ✨ Updated the max length on shop's `branding.returns.email_content.marketing_content` to 500 characters.