### PR TITLE
:lock: Landed cost requires broker.member

### DIFF
--- a/specification/paths/CalculateLandedCosts.json
+++ b/specification/paths/CalculateLandedCosts.json
@@ -6,7 +6,8 @@
     "security": [
       {
         "OAuth2": [
-          "landed_cost"
+          "landed_cost",
+          "broker.member"
         ]
       }
     ],

--- a/specification/paths/Suggest-hscode.json
+++ b/specification/paths/Suggest-hscode.json
@@ -6,7 +6,8 @@
     "security": [
       {
         "OAuth2": [
-          "landed_cost"
+          "landed_cost",
+          "broker.member"
         ]
       }
     ],


### PR DESCRIPTION
## Changes
- 🔒 Added `broker.member` as required scope for landed cost endpoints.

## Related Issues
- https://myparcelcombv.atlassian.net/browse/MP-7312