### PR TITLE
Bug + incorrect type fix

### DIFF
--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -223,7 +223,7 @@
               "type": "string",
               "readOnly": true,
               "example": "https://my-return-portal-domain.com",
-              "description": "The domain used as the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
+              "description": "The URL used as the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
             },
             "return_portal_locales": {
               "type": "array",

--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -7,6 +7,7 @@
       "properties": {
         "attributes": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",
@@ -217,6 +218,12 @@
                   "description": "The default language that is used for emails and webpages for this shop."
                 }
               ]
+            },
+            "return_portal_url": {
+              "type": "string",
+              "readOnly": true,
+              "example": "https://my-return-portal-domain.com",
+              "description": "The domain used as the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
             },
             "return_portal_locales": {
               "type": "array",

--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -223,7 +223,7 @@
               "type": "string",
               "readOnly": true,
               "example": "https://my-return-portal-domain.com",
-              "description": "The URL used as the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
+              "description": "The URL used for the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
             },
             "return_portal_locales": {
               "type": "array",

--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -222,7 +222,7 @@
             "return_portal_url": {
               "type": "string",
               "readOnly": true,
-              "example": "https://my-return-portal-domain.com",
+              "example": "https://return.myparcel.com/my-shop",
               "description": "The URL used for the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
             },
             "return_portal_locales": {

--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -7,7 +7,6 @@
       "properties": {
         "attributes": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",

--- a/specification/schemas/shops/ShopResponse.json
+++ b/specification/schemas/shops/ShopResponse.json
@@ -36,10 +36,7 @@
               ]
             },
             "return_portal_url": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": "string",
               "example": "https://my-return-portal-domain.com",
               "description": "The domain used as the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
             },

--- a/specification/schemas/shops/ShopResponse.json
+++ b/specification/schemas/shops/ShopResponse.json
@@ -35,11 +35,6 @@
                 "country_code"
               ]
             },
-            "return_portal_url": {
-              "type": "string",
-              "example": "https://my-return-portal-domain.com",
-              "description": "The domain used as the return portal for this shop. If not set, defaults to the return portal domain of the broker followed by the shop's name. E.g. `https://return.myparcel.com/my-shop`"
-            },
             "branding": {
               "properties": {
                 "returns": {


### PR DESCRIPTION
The `Shop` should have not had the `additionalProperties=false`. It made the schema fail as now we have a required property `return_portal_url` which is part of the `ShopResponse`.

I used this as an opportunity to fix another inaccuracy which is that `return_portal_url` will always resolve to a valid string making `null` an invalid type. Fixed as well

NOTE: we went with @NickVries suggestions of utilizing `readOnly` [here](https://github.com/MyParcelCOM/api-specification/pull/1204#discussion_r2151872154)