### PR TITLE
MP-7498 Readonly image urls on shop

### DIFF
--- a/specification/schemas/shops/Shop.json
+++ b/specification/schemas/shops/Shop.json
@@ -66,12 +66,6 @@
                       "example": "my-return-domain.com",
                       "description": "The domain where the return portal for this shop is hosted."
                     },
-                    "logo_url": {
-                      "$ref": "#/components/schemas/ImageUrl"
-                    },
-                    "banner_url": {
-                      "$ref": "#/components/schemas/ImageUrl"
-                    },
                     "primary_color": {
                       "type": "string",
                       "minLength": 4,
@@ -173,9 +167,6 @@
                     },
                     {
                       "properties": {
-                        "logo_url": {
-                          "$ref": "#/components/schemas/ImageUrl"
-                        },
                         "hide_customer_reference": {
                           "type": "boolean",
                           "example": false,

--- a/specification/schemas/shops/ShopResponse.json
+++ b/specification/schemas/shops/ShopResponse.json
@@ -39,12 +39,25 @@
               "properties": {
                 "returns": {
                   "properties": {
+                    "logo_url": {
+                      "$ref": "#/components/schemas/ImageUrl"
+                    },
+                    "banner_url": {
+                      "$ref": "#/components/schemas/ImageUrl"
+                    },
                     "email_content": {
                       "properties": {
                         "footer_image_url": {
                           "$ref": "#/components/schemas/ImageUrl"
                         }
                       }
+                    }
+                  }
+                },
+                "tracking": {
+                  "properties": {
+                    "logo_url": {
+                      "$ref": "#/components/schemas/ImageUrl"
                     }
                   }
                 }


### PR DESCRIPTION
## Changes
- 🔥 Removed `logo_url` from POST Shop `branding.tracking` and `branding.returns` attributes.
- 🔥 Removed `banner_url` from POST Shop `branding.returns` attribute
- ♻️ Updated ShopResponse schema to include the above attributes instead.

## Related issues
- https://myparcelcombv.atlassian.net/browse/MP-7498