### PR TITLE
[Hotfix] invitations tag changed to Onboarding

### DIFF
--- a/specification/paths/Onboarding-v1-invitations-invitation_id-onboard.json
+++ b/specification/paths/Onboarding-v1-invitations-invitation_id-onboard.json
@@ -6,7 +6,7 @@
   ],
   "post": {
     "tags": [
-      "Invitations"
+      "Onboarding"
     ],
     "security": [
       {

--- a/specification/paths/Onboarding-v1-invitations-invitation_id.json
+++ b/specification/paths/Onboarding-v1-invitations-invitation_id.json
@@ -6,7 +6,7 @@
   ],
   "get": {
     "tags": [
-      "Invitations"
+      "Onboarding"
     ],
     "security": [
       {

--- a/specification/paths/Onboarding-v1-invitations.json
+++ b/specification/paths/Onboarding-v1-invitations.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "tags": [
-      "Invitations"
+      "Onboarding"
     ],
     "security": [
       {
@@ -95,7 +95,7 @@
   },
   "post": {
     "tags": [
-      "Invitations"
+      "Onboarding"
     ],
     "security": [
       {

--- a/specification/tags.json
+++ b/specification/tags.json
@@ -70,9 +70,6 @@
     }
   },
   {
-    "name": "Invitations"
-  },
-  {
     "name": "Invoices"
   },
   {
@@ -97,6 +94,9 @@
   },
   {
     "name": "Marketplaces"
+  },
+  {
+    "name": "Onboarding"
   },
   {
     "name": "Organizations",


### PR DESCRIPTION
# Changes
- This ticket is part of the refactor done in [this](https://github.com/MyParcelCOM/api/pull/3888) PR

Following a discussion with @yoan-myparcel we decided to rename the `Invitations` domain/namespace to `Onboarding` to be more concrete.