### PR TITLE
🐛 PUDO location response should not list street_number as required

### DIFF
--- a/specification/schemas/pickup-dropoff-locations/PickupDropoffLocationResponse.json
+++ b/specification/schemas/pickup-dropoff-locations/PickupDropoffLocationResponse.json
@@ -22,7 +22,6 @@
               "required": [
                 "company",
                 "street_1",
-                "street_number",
                 "city",
                 "country_code"
               ]


### PR DESCRIPTION
Almost none of our carriers use separate street numbers. The fact that this was tagged as required is kind of wild 🤯 