### PR TITLE
:sparkles: Update configuration schema and paths

### DIFF
--- a/specification/paths/Marketplaces-v1-integrations-code-configuration-shop-id.json
+++ b/specification/paths/Marketplaces-v1-integrations-code-configuration-shop-id.json
@@ -47,24 +47,7 @@
                       "$ref": "#/components/schemas/Configuration"
                     },
                     "values": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                          "name",
-                          "value"
-                        ],
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "example": "orderPrefix"
-                          },
-                          "value": {
-                            "type": "string",
-                            "example": "myparcelcom_"
-                          }
-                        }
-                      }
+                      "$ref": "#/components/schemas/ConfigurationValues"
                     }
                   }
                 }

--- a/specification/paths/Marketplaces-v1-integrations-code-configure-shop-id.json
+++ b/specification/paths/Marketplaces-v1-integrations-code-configure-shop-id.json
@@ -38,38 +38,7 @@
             "additionalProperties": false,
             "properties": {
               "data": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": [
-                  "properties"
-                ],
-                "properties": {
-                  "properties": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "required": [
-                        "name",
-                        "value"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "example": "orderPrefix"
-                        },
-                        "value": {
-                          "type": [
-                            "string",
-                            "number",
-                            "boolean"
-                          ],
-                          "example": "shopify_"
-                        }
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/ConfigurationValues"
               }
             }
           }

--- a/specification/paths/Wms-v1-integrations-code-configuration-shop-id.json
+++ b/specification/paths/Wms-v1-integrations-code-configuration-shop-id.json
@@ -43,24 +43,7 @@
                       "$ref": "#/components/schemas/Configuration"
                     },
                     "values": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                          "name",
-                          "value"
-                        ],
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "example": "anotherConfigurableProperty"
-                          },
-                          "value": {
-                            "type": "string",
-                            "example": "yetAnotherValue"
-                          }
-                        }
-                      }
+                      "$ref": "#/components/schemas/ConfigurationValues"
                     }
                   }
                 }

--- a/specification/paths/Wms-v1-integrations-code-configure-shop-id.json
+++ b/specification/paths/Wms-v1-integrations-code-configure-shop-id.json
@@ -34,38 +34,7 @@
             "additionalProperties": false,
             "properties": {
               "data": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": [
-                  "properties"
-                ],
-                "properties": {
-                  "properties": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "required": [
-                        "name",
-                        "value"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "example": "orderPrefix"
-                        },
-                        "value": {
-                          "type": [
-                            "string",
-                            "number",
-                            "boolean"
-                          ],
-                          "example": "shopify_"
-                        }
-                      }
-                    }
-                  }
-                }
+                "$ref": "#/components/schemas/ConfigurationValues"
               }
             }
           }

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -161,6 +161,9 @@
   "ConfigurationSchemaProperty": {
     "$ref": "./schemas/ConfigurationSchemaProperty.json"
   },
+  "ConfigurationValues": {
+    "$ref": "./schemas/ConfigurationValues.json"
+  },
   "PackageType": {
     "$ref": "./schemas/PackageType.json"
   },

--- a/specification/schemas.json
+++ b/specification/schemas.json
@@ -158,6 +158,9 @@
   "Configuration": {
     "$ref": "./schemas/Configuration.json"
   },
+  "ConfigurationSchemaProperty": {
+    "$ref": "./schemas/ConfigurationSchemaProperty.json"
+  },
   "PackageType": {
     "$ref": "./schemas/PackageType.json"
   },

--- a/specification/schemas/Configuration.json
+++ b/specification/schemas/Configuration.json
@@ -10,7 +10,9 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "enum": ["http://json-schema.org/draft-04/schema#"]
+      "enum": [
+        "http://json-schema.org/draft/2020-12/schema"
+      ]
     },
     "additionalProperties": {
       "type": "boolean",
@@ -19,79 +21,69 @@
       ]
     },
     "required": {
+      "description": "Array of required schema properties",
       "type": "array",
       "items": {
         "type": "string",
-        "example": "examplePrefix"
+        "example": "schema-property"
       }
     },
     "properties": {
+      "description": "<a href=\"https://json-schema.org/learn/getting-started-step-by-step#define-properties\" target=\"_blank\">JSON schema properties</a>. They key is the name of the property and the value is an object that describes its attributes.",
       "type": "object",
+      "additionalProperties": {
+        "$ref": "#/components/schemas/ConfigurationSchemaProperty"
+      },
       "example": {
-        "examplePrefix": {
+        "minimal_text_property": {
           "type": "string",
-          "description": "Example prefix",
+          "description": "Example Text Field"
+        },
+        "select_property": {
+          "type": "string",
+          "description": "Example Select Field",
           "enum": [
-            "myIntegrations_",
-            "yetAnotherIntegration_",
-            "myparcelcom_"
+            "option_1_key",
+            "option_2_key"
           ],
           "meta": {
-            "help": "An example prefix for resources handled by our system"
+            "help": "Please select an option.",
+            "field_type": "select",
+            "label_translations": {
+              "de-DE": "Beispiel Selectfeld",
+              "en-GB": "Example Select Field"
+            },
+            "enum_labels": {
+              "option_1_key": "Option 1 Label",
+              "option_2_key": "Option 2 Label"
+            },
+            "enum_label_translations": {
+              "option_1_key": {
+                "de-DE": "Option 1 Beschriftung",
+                "en-GB": "Option 1 Label"
+              },
+              "option_2_key": {
+                "de-DE": "Option 2 Beschriftung",
+                "en-GB": "Option 2 Label"
+              }
+            }
           }
         },
-        "anotherConfigurableProperty": {
-          "type": "number",
-          "description": "Another configurable property"
-        }
-      },
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "type",
-          "description"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "example": "string",
-            "enum": [
-              "string",
-              "number",
-              "boolean"
-            ]
-          },
-          "description": {
-            "type": "string",
-            "example": "Example prefix"
-          },
-          "enum": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "example": "myPrefix_"
-                },
-                {
-                  "type": "number",
-                  "example": "1000_"
-                }
-              ]
-            }
-          },
-          "meta": {
-            "type": "object",
-            "properties": {
-              "help": {
-                "type": "string",
-                "example": "A prefix that will be applied to resources handled by our system"
-              },
-              "password": {
-                "type": "boolean",
-                "example": false
-              }
+        "nested_group": {
+          "type": "object",
+          "description": "Nested group",
+          "properties": {
+            "text_group_child": {
+              "type": "string",
+              "description": "Text group Child"
+            },
+            "number_group_child": {
+              "type": "number",
+              "description": "Number group Child"
+            },
+            "boolean_group_child": {
+              "type": "boolean",
+              "description": "Boolean group Child"
             }
           }
         }

--- a/specification/schemas/ConfigurationSchemaProperty.json
+++ b/specification/schemas/ConfigurationSchemaProperty.json
@@ -1,0 +1,157 @@
+{
+  "description": "A JSON Schema property",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "description"
+  ],
+  "properties": {
+    "type": {
+      "description": "The data type of the schema property",
+      "type": "string",
+      "example": "string",
+      "enum": [
+        "string",
+        "number",
+        "boolean",
+        "object",
+        "array"
+      ]
+    },
+    "description": {
+      "description": "The description of the schema property",
+      "type": "string",
+      "example": "Example schema property"
+    },
+    "required": {
+      "description": "Array of required schema properties. Used when the `properties` attribute contains nested schema",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "example": "exampleSchemaPropertyName"
+      }
+    },
+    "items": {
+      "type": "object",
+      "description": "Item type and enum values for `array` type properties",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Data type of the enum values",
+          "enum": [
+            "string"
+          ],
+          "example": "string"
+        },
+        "enum": {
+          "type": "array",
+          "description": "Enum values for schema type properties",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "value-1",
+            "value-2"
+          ]
+        }
+      }
+    },
+    "enum": {
+      "type": "array",
+      "description": "Enum values for schema properties",
+      "items": {
+        "type": "string"
+      },
+      "example": [
+        "enum-value-1",
+        "enum-value-2"
+      ]
+    },
+    "properties": {
+      "description": "Nested JSON schema properties that follow the same specification",
+      "example": {
+        "nested": {
+          "schema": {
+            "property": {}
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "Properties that fall outside the JSON schema specification, which can be used to inform the UI about how to render the schema property as a form input",
+      "properties": {
+        "help": {
+          "type": "string",
+          "description": "A help message that describes the schema property",
+          "example": "This is a help message for the schema property"
+        },
+        "password": {
+          "type": "boolean",
+          "description": "Indicates whether the value of the schema property should be hidden",
+          "example": false
+        },
+        "field_type": {
+          "type": "string",
+          "description": "Indicates the type of (input) UI that is expected to render this schema property. Used to differentiate between properties that have the same schema format",
+          "enum": [
+            "select",
+            "radio"
+          ],
+          "example": "radio"
+        },
+        "label_translations": {
+          "type": "object",
+          "description": "Key/value pair where the key is a locale code, e.g. \"en-GB\", and the value is the translated `description` of the schema property",
+          "patternProperties": {
+            "[az]{2}-[AZ]{2}": {
+              "type": "string",
+              "description": "The translated description of the schema property"
+            }
+          },
+          "example": {
+            "de-DE": "The description of the schema property in German",
+            "fr-FR": "The description of the schema property in French"
+          }
+        },
+        "enum_labels": {
+          "type": "object",
+          "description": "Key/value pair where the key is a schema property enum value and the value is a human readable label",
+          "additionalProperties": {
+            "description": "Human readable label",
+            "type": "string"
+          },
+          "example": {
+            "enum-value-1": "Enum value 1",
+            "enum-value-2": "Enum value 2"
+          }
+        },
+        "enum_label_translations": {
+          "type": "object",
+          "description": "Key/value pair where the key is a schema property enum value and the value is an object with translated human readable labels",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Key/value pair where the key is a locale code, e.g. \"en-GB\", and the value is a translated human readable label",
+            "patternProperties": {
+              "[az]{2}-[AZ]{2}": {
+                "description": "Translated human readable label",
+                "type": "string"
+              }
+            }
+          },
+          "example": {
+            "enum-value-1": {
+              "de-DE": "Enum value 1 in German",
+              "fr-FR": "Enum value 1 in French"
+            },
+            "enum-value-2": {
+              "de-DE": "Enum value 2 in German",
+              "fr-FR": "Enum value 2 in French"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/schemas/ConfigurationSchemaProperty.json
+++ b/specification/schemas/ConfigurationSchemaProperty.json
@@ -34,12 +34,12 @@
     },
     "items": {
       "type": "object",
-      "description": "Item type and enum values for `array` type properties",
+      "description": "<a href=\"https://json-schema.org/understanding-json-schema/reference/array#items\">JSON schema array items</a>. Only used when the schema property type is `array`",
       "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
-          "description": "Data type of the enum values",
+          "description": "Data type of the enum values. Only valid value is \"string\"",
           "enum": [
             "string"
           ],
@@ -47,7 +47,7 @@
         },
         "enum": {
           "type": "array",
-          "description": "Enum values for schema type properties",
+          "description": "Enum values for schema type properties. Only `string` values are supported",
           "items": {
             "type": "string"
           },
@@ -70,7 +70,10 @@
       ]
     },
     "properties": {
-      "description": "Nested JSON schema properties that follow the same specification",
+      "description": "Nested schema properties of type `object`, following the <a href=\"https://json-schema.org/understanding-json-schema/reference/object#properties\">object specification</a>. Object schemas can be nested indefinitely under the `properties` key",
+      "additionalProperties": {
+        "type": "object"
+      },
       "example": {
         "nested": {
           "schema": {
@@ -81,7 +84,7 @@
     },
     "meta": {
       "type": "object",
-      "description": "Properties that fall outside the JSON schema specification, which can be used to inform the UI about how to render the schema property as a form input",
+      "description": "Properties beyond the JSON Schema specification that help determine how a schema property should be rendered in a form",
       "additionalProperties": false,
       "properties": {
         "help": {
@@ -91,7 +94,7 @@
         },
         "password": {
           "type": "boolean",
-          "description": "Indicates whether the value of the schema property should be hidden",
+          "description": "Indicates whether the value of the schema property should be masked. Only used when the schema property type is `string`",
           "example": false
         },
         "field_type": {
@@ -120,7 +123,7 @@
         },
         "enum_labels": {
           "type": "object",
-          "description": "Key/value pair where the key is a schema property enum value and the value is a human readable label",
+          "description": "Key/value pair using enum values as keys and human-readable labels as values",
           "additionalProperties": {
             "description": "Human readable label",
             "type": "string"
@@ -132,10 +135,10 @@
         },
         "enum_label_translations": {
           "type": "object",
-          "description": "Key/value pair where the key is a schema property enum value and the value is an object with translated human readable labels",
+          "description": "Key/value pair using enum values as keys and objects containing translated human-readable labels as values",
           "additionalProperties": {
             "type": "object",
-            "description": "Key/value pair where the key is a locale code, e.g. \"en-GB\", and the value is a translated human readable label",
+            "description": "Key/value pair using locale codes as keys (e.g. \"en-GB\"), and translated human readable labels as values",
             "additionalProperties": false,
             "patternProperties": {
               "^[a-z]{2}-[A-Z]{2}$": {

--- a/specification/schemas/ConfigurationSchemaProperty.json
+++ b/specification/schemas/ConfigurationSchemaProperty.json
@@ -108,7 +108,7 @@
           "description": "Key/value pair where the key is a locale code, e.g. \"en-GB\", and the value is the translated `description` of the schema property",
           "additionalProperties": false,
           "patternProperties": {
-            "[az]{2}-[AZ]{2}": {
+            "^[a-z]{2}-[A-Z]{2}$": {
               "type": "string",
               "description": "The translated description of the schema property"
             }
@@ -136,8 +136,9 @@
           "additionalProperties": {
             "type": "object",
             "description": "Key/value pair where the key is a locale code, e.g. \"en-GB\", and the value is a translated human readable label",
+            "additionalProperties": false,
             "patternProperties": {
-              "[az]{2}-[AZ]{2}": {
+              "^[a-z]{2}-[A-Z]{2}$": {
                 "description": "Translated human readable label",
                 "type": "string"
               }

--- a/specification/schemas/ConfigurationSchemaProperty.json
+++ b/specification/schemas/ConfigurationSchemaProperty.json
@@ -35,6 +35,7 @@
     "items": {
       "type": "object",
       "description": "Item type and enum values for `array` type properties",
+      "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
@@ -81,6 +82,7 @@
     "meta": {
       "type": "object",
       "description": "Properties that fall outside the JSON schema specification, which can be used to inform the UI about how to render the schema property as a form input",
+      "additionalProperties": false,
       "properties": {
         "help": {
           "type": "string",
@@ -104,6 +106,7 @@
         "label_translations": {
           "type": "object",
           "description": "Key/value pair where the key is a locale code, e.g. \"en-GB\", and the value is the translated `description` of the schema property",
+          "additionalProperties": false,
           "patternProperties": {
             "[az]{2}-[AZ]{2}": {
               "type": "string",

--- a/specification/schemas/ConfigurationValues.json
+++ b/specification/schemas/ConfigurationValues.json
@@ -7,10 +7,12 @@
   "example": {
     "minimal_text_property": "previously-set-value",
     "select_property": "option_2_key",
-    "nested_group": {
-      "text_group_child": "some_value",
-      "number_group_child": 0,
-      "boolean_group_child": false
+    "group": {
+      "nested_group": {
+        "text_group_child": "some_value",
+        "number_group_child": 0,
+        "boolean_group_child": false
+      }
     }
   }
 }

--- a/specification/schemas/ConfigurationValues.json
+++ b/specification/schemas/ConfigurationValues.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "description": "Key/value pairs with the schema property names as keys and their respective values. Nested schema property groups are respected",
+  "additionalProperties": {
+    "description": "The schema property value"
+  },
+  "example": {
+    "minimal_text_property": "previously-set-value",
+    "select_property": "option_2_key",
+    "nested_group": {
+      "text_group_child": "some_value",
+      "number_group_child": 0,
+      "boolean_group_child": false
+    }
+  }
+}


### PR DESCRIPTION
As mentioned in the ticket, I tried to make a recursive schema, in order to support validating the potentially nested schema properties, but Redoc would no longer render the UI if I used a self-referencing schema... This sucks, because a recursive schema is valid and we could use it for validation, but it is not compatible with the package that has to _render_ that schema... I (think) I get it from their point of view: how do you render a schema that potentially goes on infinitely? But it is bad for us that it limits us in our validating capacities.

I'm open to suggestions on what to do about it, other than just accept it. I have added a nested property with an explanatory comment that states that this is where nested properties should go and that they should adhere to the same schema, but there's no way to enforce it. Having said that, we are the only creators of the schema response and we use the json-schema-form-builder for it, which should always provide us with a valid schema.

**Changes**
- ✨ add extensive `ConfigurationSchemaProperty` specification
- ✨ Update `Configuration` specification with `ConfigurationSchemaProperty` ref and example
- ✨ Create and implement `ConfigurationValues` schema

**Related issue**
https://myparcelcombv.atlassian.net/browse/MP-7650