### PR TITLE
📝 Some tweaks to the descriptions related to carrier locations

### DIFF
--- a/specification/paths/Carriers-carrier_id-PickupDropoffLocations-pudo_id.json
+++ b/specification/paths/Carriers-carrier_id-PickupDropoffLocations-pudo_id.json
@@ -34,16 +34,7 @@
               "additionalProperties": false,
               "properties": {
                 "data": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/PickupDropoffLocation"
-                    },
-                    {
-                      "required": [
-                        "id"
-                      ]
-                    }
-                  ]
+                  "$ref": "#/components/schemas/PickupDropoffLocationResponse"
                 }
               }
             }

--- a/specification/schemas/shipments/DropOffLocation.json
+++ b/specification/schemas/shipments/DropOffLocation.json
@@ -5,11 +5,10 @@
     "code": {
       "type": "string",
       "example": "205604",
-      "description": "Code of the drop-off location, retrieved from the `pickup-dropoff-locations` endpoint."
+      "description": "Code of the carrier location where the **sender** must drop off the parcel, retrieved from the `pickup-dropoff-locations` endpoint."
     },
     "address": {
       "$ref": "#/components/schemas/BaseAddress"
     }
-  },
-  "description": "Required if the service handover method is `drop-off`."
+  }
 }

--- a/specification/schemas/shipments/PickupLocation.json
+++ b/specification/schemas/shipments/PickupLocation.json
@@ -4,11 +4,11 @@
   "properties": {
     "code": {
       "type": "string",
-      "example": "205604"
+      "example": "205604",
+      "description": "Code of the carrier location where the parcel is to be picked up by the **recipient**, retrieved from the `pickup-dropoff-locations` endpoint."
     },
     "address": {
       "$ref": "#/components/schemas/BaseAddress"
     }
-  },
-  "description": "Required if the service delivery method is `pick-up`."
+  }
 }

--- a/specification/schemas/shipments/Shipment.json
+++ b/specification/schemas/shipments/Shipment.json
@@ -57,7 +57,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Required if the service delivery method is `pick-up`."
             },
             "drop_off_location": {
               "oneOf": [


### PR DESCRIPTION
Some tweaks to the descriptions related to carrier locations.

Also the get-by-id endpoint showed no required attributes, so I used the `PickupDropoffLocationResponse` instead.